### PR TITLE
Updated batch selection feature

### DIFF
--- a/erpnext/public/js/utils/serial_batch_selector.js
+++ b/erpnext/public/js/utils/serial_batch_selector.js
@@ -386,7 +386,10 @@ erpnext.stock.SerialBatchSelector = Class.extend({
 						}
 
 						this.doc.qty += batch.selected_qty
-						console.log(key, this.doc.grouped_qty)
+					}
+
+					if (!this.item.batch_no) {
+						this.doc.qty += this.item.qty
 					}
 
 					this.dialog.fields_dict.batches.grid.df.data = this.doc.batches;

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -333,7 +333,7 @@ def round_down(value, decimals):
 
 @frappe.whitelist()
 def get_sufficient_batch_or_fifo(item_code, warehouse, qty=1.0, conversion_factor=1.0, batches_used=None,
-		include_empty_batch=False, precision=None):
+		include_empty_batch=False, precision=None, include_unselected_batches=False):
 	if not warehouse or not qty:
 		return []
 
@@ -362,7 +362,16 @@ def get_sufficient_batch_or_fifo(item_code, warehouse, qty=1.0, conversion_facto
 
 	for batch in batches:
 		if remaining_stock_qty <= 0:
-			break
+			if include_unselected_batches:
+				selected_batches.append(frappe._dict({
+					'batch_no': batch.name,
+					'available_qty': batch.qty / conversion_factor,
+					'selected_qty': 0
+				}))
+
+				continue
+			else:
+				break
 
 		selected_stock_qty = min(remaining_stock_qty, batch.qty)
 		selected_qty = round_down(selected_stock_qty / conversion_factor, precision)


### PR DESCRIPTION
- Updated get_sufficient_batch_or_fifo method to return batches not selected.
- Moved API call from callback to its own function load_all_batches in serial_batch_selector.js.
- Used key value pairs to keep track of selected quantities of selected batches.
- Updated logic to merge rows after selection.
- Fixed issue in total quantity value while batch selection.