### PR TITLE
fix: Payroll Issues

### DIFF
--- a/erpnext/hr/doctype/additional_salary/additional_salary.py
+++ b/erpnext/hr/doctype/additional_salary/additional_salary.py
@@ -58,7 +58,7 @@ def get_additional_salary_component(employee, start_date, end_date, component_ty
 	}, as_dict=1)
 
 	additional_components_list = []
-	component_fields = ["depends_on_payment_days", "salary_component_abbr", "is_tax_applicable", "variable_based_on_taxable_salary", 'type']
+	component_fields = ["depends_on_payment_days", "salary_component_abbr", "is_tax_applicable", "variable_based_on_taxable_salary", 'type' , 'do_not_include_in_total']
 	for d in additional_components:
 		struct_row = frappe._dict({'salary_component': d.salary_component})
 		component = frappe.get_all("Salary Component", filters={'name': d.salary_component}, fields=component_fields)

--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.js
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.js
@@ -268,6 +268,10 @@ frappe.ui.form.on('Payroll Entry', {
 		frm.toggle_reqd(['payroll_frequency'], !frm.doc.salary_slip_based_on_timesheet);
 	},
 
+	posting_date: function(frm){
+		frm.trigger('set_start_end_dates');
+	},
+
 	set_start_end_dates: function (frm) {
 		if (!frm.doc.salary_slip_based_on_timesheet) {
 			frappe.call({

--- a/erpnext/hr/doctype/salary_slip/salary_slip.js
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.js
@@ -97,12 +97,33 @@ frappe.ui.form.on("Salary Slip", {
 	},
 
 	payroll_frequency: function(frm) {
-		frm.trigger("toggle_fields");
-		frm.set_value('end_date', '');
+		frm.trigger('set_start_end_dates');
 	},
 
 	employee: function(frm) {
 		frm.events.get_emp_and_leave_details(frm);
+	},
+
+	posting_date: function(frm){
+		frm.trigger('set_start_end_dates');
+	},
+
+	set_start_end_dates: function (frm) {
+		if (!frm.doc.salary_slip_based_on_timesheet) {
+			frappe.call({
+				method: 'erpnext.hr.doctype.payroll_entry.payroll_entry.get_start_end_dates',
+				args: {
+					payroll_frequency: frm.doc.payroll_frequency,
+					start_date: frm.doc.posting_date
+				},
+				callback: function (r) {
+					if (r.message) {
+						frm.set_value('start_date', r.message.start_date);
+						frm.set_value('end_date', r.message.end_date);
+					}
+				}
+			});
+		}
 	},
 
 	leave_without_pay: function(frm){

--- a/erpnext/hr/doctype/salary_slip/salary_slip.js
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.js
@@ -157,9 +157,6 @@ frappe.ui.form.on("Salary Slip", {
 	toggle_fields: function(frm) {
 		frm.toggle_display(['hourly_wages', 'timesheets'], cint(frm.doc.salary_slip_based_on_timesheet)===1);
 
-		frm.toggle_display(['payment_days', 'total_working_days', 'leave_without_pay'],
-			frm.doc.payroll_frequency!="");
-
 		frm.set_df_property('leave_without_pay', 'read_only', cint(frm.doc.set_lwp_manually) ? 0 : 1);
 		frm.set_df_property('late_days', 'read_only', cint(frm.doc.set_lwp_manually) ? 0 : 1);
 

--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -39,6 +39,9 @@ class SalarySlip(TransactionBase):
 	def autoname(self):
 		self.name = make_autoname(self.series)
 
+	def before_validate_links(self):
+		self.loans = []
+
 	def validate(self):
 		self.status = self.get_status()
 		self.validate_dates()


### PR DESCRIPTION
- Adding a component from additional salary to a salary slip does not add a checkbox (do_not_include_in_total). Create salary slip, create an additional salary for the mobile deduction, updated the salary slip mobile deduction amount was fetched from additional salary, but do_not_include_in_total checkbox value was not being fetched along with other salary component configurations

- If a loan linked with a salary is canceled and the user wants to remove the loan from the salary slip using the update salary slip button, an error message is displayed instead of removing the corresponding row.

- When the user selects a monthly Payroll Frequency and manually enters a Posting Date in the Salary Slip, the system automatically calculates and sets the From Date to the 1st of that same month and the To Date to the last day of that month. For instance, if the posting date is October 31st, the system automatically assigns the From Date as October 1st and the To Date as October 31st in the Salary Slip.

closes https://github.com/ParaLogicTech/erpnext/issues/256

closes  https://github.com/ParaLogicTech/erpnext/issues/267

closes https://github.com/ParaLogicTech/erpnext/issues/268
