### PR TITLE
feat(Workshop CP): Permissions for Controller / Project User (Read Only)

### DIFF
--- a/erpnext/domains/vehicles.py
+++ b/erpnext/domains/vehicles.py
@@ -323,12 +323,18 @@ item_fields = [
 		"insert_after": "vehicle_allocation_required", "depends_on": "vehicle_allocation_required", "ignore_user_permissions": 1},
 ]
 
+# Employee Fields
+employee_fields = [
+	{"label": "Is Technician", "fieldname": "is_Technician", "fieldtype": "Check",
+		"insert_after": "designation"},
+]
+
 # Set Translatable = 0
 field_lists = [
 	applies_to_fields, applies_to_transaction_fields, applies_to_project_fields, applies_to_appointment_fields,
 	project_vehicle_reading_fields, vehicle_owner_fields, sales_invoice_vehicle_owner_fields, service_person_fields,
 	material_request_service_person_fields, accounting_dimension_fields, accounting_dimension_table_fields,
-	item_fields, project_fields, project_type_fields, project_change_vehicle_details_fields,
+	item_fields, employee_fields, project_fields, project_type_fields, project_change_vehicle_details_fields,
 	project_template_fields, project_template_category_fields, project_template_detail_fields,
 	customer_vehicle_selector_fields, project_customer_vehicle_selector, appointment_customer_vehicle_selector,
 	customer_customer_vehicle_selector, opportunity_fields, applies_to_opportunity_fields,
@@ -435,6 +441,7 @@ data = {
 		"Customer": customer_customer_vehicle_selector,
 		"Opportunity": opportunity_fields + applies_to_opportunity_fields,
 		"Customer Feedback": applies_to_transaction_fields,
+		"Employee": employee_fields
 	},
 	'default_portal_role': 'Customer'
 }

--- a/erpnext/hr/doctype/employee/employee.json
+++ b/erpnext/hr/doctype/employee/employee.json
@@ -886,7 +886,7 @@
  "idx": 24,
  "image_field": "image",
  "links": [],
- "modified": "2023-06-21 00:28:01.131618",
+ "modified": "2023-10-31 17:12:11.509299",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee",
@@ -935,6 +935,11 @@
   {
    "role": "Projects User",
    "select": 1
+  },
+  {
+   "read": 1,
+   "role": "Projects User (Read Only)",
+   "write": 1
   },
   {
    "role": "Stock User",

--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.json
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "naming_series:",
  "creation": "2013-01-10 16:34:30",
  "doctype": "DocType",
@@ -175,10 +176,12 @@
   }
  ],
  "idx": 1,
- "modified": "2022-12-21 19:03:52.761522",
+ "links": [],
+ "modified": "2023-10-31 15:28:12.586010",
  "modified_by": "Administrator",
  "module": "Maintenance",
  "name": "Maintenance Schedule",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -192,6 +195,15 @@
    "role": "Projects User",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
   },
   {
    "email": 1,
@@ -214,6 +226,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1,
  "track_seen": 1
 }

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -817,7 +817,7 @@ erpnext.patches.v14_0.trim_packing_slip_table
 execute:frappe.delete_doc_if_exists("Report", "Batch Balance")
 execute:frappe.delete_doc_if_exists("Report", "Warehouse wise Item Balance Age and Value")
 execute:frappe.delete_doc_if_exists("Custom Field", "Customer-reference")
-erpnext.patches.v12_0.resetup_vehicle_domain #12-01-2023 #02-02-2023 #07-03-2023
+erpnext.patches.v12_0.resetup_vehicle_domain #12-01-2023 #02-02-2023 #07-03-2023 #30-10-2023
 erpnext.patches.v12_0.update_total_panel_qty_in_project
 execute:frappe.delete_doc_if_exists("Custom Field", "Customer_date_of_birth")
 erpnext.patches.v12_0.update_detailed_sales_data_in_project

--- a/erpnext/projects/doctype/activity_type/activity_type.json
+++ b/erpnext/projects/doctype/activity_type/activity_type.json
@@ -47,7 +47,7 @@
  "icon": "icon-flag",
  "idx": 1,
  "links": [],
- "modified": "2023-08-30 23:11:23.208620",
+ "modified": "2023-10-31 15:23:56.898232",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Activity Type",
@@ -76,6 +76,14 @@
    "role": "Projects User",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
   },
   {
    "role": "Employee",

--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -1389,7 +1389,7 @@
  "idx": 29,
  "image_field": "image",
  "links": [],
- "modified": "2023-10-21 00:51:10.132474",
+ "modified": "2023-10-31 15:22:02.538929",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",
@@ -1406,6 +1406,14 @@
    "role": "Projects User",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
   },
   {
    "create": 1,

--- a/erpnext/projects/doctype/project_status/project_status.json
+++ b/erpnext/projects/doctype/project_status/project_status.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:project_status",
  "creation": "2022-04-08 00:51:50.091071",
@@ -92,10 +93,12 @@
    "label": "User Can Set Manually"
   }
  ],
- "modified": "2022-04-24 00:57:38.961553",
+ "links": [],
+ "modified": "2023-10-31 15:30:34.573181",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project Status",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -129,6 +132,15 @@
    "read": 1,
    "report": 1,
    "role": "Projects User",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
    "share": 1
   },
   {
@@ -189,5 +201,6 @@
  "quick_entry": 1,
  "sort_field": "sorting_index",
  "sort_order": "ASC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/projects/doctype/project_template/project_template.json
+++ b/erpnext/projects/doctype/project_template/project_template.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:project_template_code",
  "creation": "2019-02-18 17:23:11.708371",
@@ -124,10 +125,12 @@
    "fieldtype": "Column Break"
   }
  ],
- "modified": "2022-12-06 15:19:48.606564",
+ "links": [],
+ "modified": "2023-10-31 15:28:40.701819",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project Template",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -149,6 +152,15 @@
    "read": 1,
    "report": 1,
    "role": "Projects User",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
    "share": 1
   },
   {
@@ -191,6 +203,7 @@
  "search_fields": "project_template_name, project_template_category, applies_to_item_name",
  "sort_field": "idx",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "project_template_name",
  "track_changes": 1
 }

--- a/erpnext/projects/doctype/project_template_category/project_template_category.json
+++ b/erpnext/projects/doctype/project_template_category/project_template_category.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:project_template_category",
  "creation": "2022-04-07 00:25:56.715772",
@@ -24,10 +25,12 @@
    "label": "Description"
   }
  ],
- "modified": "2022-04-07 00:25:56.715772",
+ "links": [],
+ "modified": "2023-10-31 15:30:58.755807",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project Template Category",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -49,6 +52,15 @@
    "read": 1,
    "report": 1,
    "role": "Projects User",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
    "share": 1
   },
   {
@@ -92,5 +104,6 @@
  "search_fields": "description",
  "sort_field": "idx",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/projects/doctype/project_type/project_type.json
+++ b/erpnext/projects/doctype/project_type/project_type.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:project_type",
  "creation": "2017-07-18 13:32:46.031115",
@@ -121,10 +122,12 @@
    "label": "Bypass Mandatory Appointment Requirement"
   }
  ],
- "modified": "2023-04-07 18:13:27.534155",
+ "links": [],
+ "modified": "2023-10-31 15:26:51.368292",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project Type",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -158,6 +161,15 @@
    "read": 1,
    "report": 1,
    "role": "Projects User",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
    "share": 1
   },
   {
@@ -218,5 +230,6 @@
  "quick_entry": 1,
  "sort_field": "idx",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/projects/doctype/project_workshop/project_workshop.json
+++ b/erpnext/projects/doctype/project_workshop/project_workshop.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:workshop_name",
  "creation": "2022-04-03 21:58:49.480874",
@@ -36,10 +37,12 @@
    "options": "Default Cost Center"
   }
  ],
- "modified": "2022-12-02 21:23:58.239826",
+ "links": [],
+ "modified": "2023-10-31 15:28:52.930477",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project Workshop",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -81,6 +84,15 @@
    "print": 1,
    "read": 1,
    "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
    "role": "Sales User",
    "share": 1
   },
@@ -105,5 +117,6 @@
  ],
  "sort_field": "idx",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -494,7 +494,7 @@
  "is_calendar_and_gantt": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2023-10-17 14:20:38.782233",
+ "modified": "2023-10-31 17:15:25.721671",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",
@@ -510,6 +510,15 @@
    "read": 1,
    "report": 1,
    "role": "Projects User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
    "share": 1,
    "write": 1
   }

--- a/erpnext/projects/doctype/timesheet/timesheet.json
+++ b/erpnext/projects/doctype/timesheet/timesheet.json
@@ -295,7 +295,7 @@
  "is_calendar_and_gantt": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-10 17:27:12.383427",
+ "modified": "2023-10-31 15:23:35.783508",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Timesheet",
@@ -317,18 +317,10 @@
    "write": 1
   },
   {
-   "amend": 1,
-   "cancel": 1,
    "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
    "read": 1,
    "report": 1,
-   "role": "HR User",
-   "share": 1,
-   "submit": 1,
+   "role": "Projects User (Read Only)",
    "write": 1
   },
   {
@@ -341,7 +333,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "Manufacturing User",
+   "role": "HR User",
    "share": 1,
    "submit": 1,
    "write": 1

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -946,7 +946,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2023-08-30 22:44:54.203324",
+ "modified": "2023-10-31 15:24:13.390490",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",
@@ -990,6 +990,10 @@
   {
    "read": 1,
    "role": "Projects User"
+  },
+  {
+   "read": 1,
+   "role": "Projects User (Read Only)"
   },
   {
    "read": 1,

--- a/erpnext/vehicles/doctype/vehicle_delivery/vehicle_delivery.json
+++ b/erpnext/vehicles/doctype/vehicle_delivery/vehicle_delivery.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "autoname": "naming_series:",
  "creation": "2021-03-14 14:32:17.358553",
@@ -645,10 +646,12 @@
  "icon": "fa fa-file-text",
  "image_field": "image",
  "is_submittable": 1,
- "modified": "2022-12-06 17:04:11.233363",
+ "links": [],
+ "modified": "2023-10-31 15:28:30.737586",
  "modified_by": "Administrator",
  "module": "Vehicles",
  "name": "Vehicle Delivery",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -692,6 +695,15 @@
    "report": 1,
    "role": "Projects User",
    "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
   }
  ],
  "restrict_to_domain": "Vehicles",
@@ -699,6 +711,7 @@
  "show_name_in_global_search": 1,
  "sort_field": "posting_date",
  "sort_order": "DESC",
+ "states": [],
  "timeline_field": "customer",
  "title_field": "title",
  "track_changes": 1,

--- a/erpnext/vehicles/doctype/vehicle_gate_pass/vehicle_gate_pass.json
+++ b/erpnext/vehicles/doctype/vehicle_gate_pass/vehicle_gate_pass.json
@@ -433,7 +433,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2023-08-13 17:32:46.344365",
+ "modified": "2023-10-31 15:24:31.320618",
  "modified_by": "Administrator",
  "module": "Vehicles",
  "name": "Vehicle Gate Pass",
@@ -522,6 +522,15 @@
    "read": 1,
    "report": 1,
    "role": "Projects User",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
    "share": 1
   }
  ],

--- a/erpnext/vehicles/doctype/vehicle_log/vehicle_log.json
+++ b/erpnext/vehicles/doctype/vehicle_log/vehicle_log.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "naming_series:",
  "creation": "2016-09-03 14:14:51.788550",
  "doctype": "DocType",
@@ -246,10 +247,12 @@
   }
  ],
  "is_submittable": 1,
- "modified": "2022-07-29 23:30:54.666418",
+ "links": [],
+ "modified": "2023-10-31 15:30:25.231636",
  "modified_by": "Administrator",
  "module": "Vehicles",
  "name": "Vehicle Log",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -296,6 +299,15 @@
    "print": 1,
    "read": 1,
    "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
    "role": "Sales Admin",
    "share": 1
   },
@@ -311,5 +323,6 @@
  ],
  "restrict_to_domain": "Vehicles",
  "sort_field": "date",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/erpnext/vehicles/doctype/vehicle_panel/vehicle_panel.json
+++ b/erpnext/vehicles/doctype/vehicle_panel/vehicle_panel.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:panel_name",
  "creation": "2022-10-19 16:21:42.593816",
@@ -26,10 +27,12 @@
    "label": "Default Qty"
   }
  ],
- "modified": "2022-11-30 16:37:27.132105",
+ "links": [],
+ "modified": "2023-10-31 15:29:51.347567",
  "modified_by": "Administrator",
  "module": "Vehicles",
  "name": "Vehicle Panel",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -62,6 +65,15 @@
    "print": 1,
    "read": 1,
    "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
    "role": "Vehicle Manager",
    "share": 1
   }
@@ -70,5 +82,6 @@
  "restrict_to_domain": "Vehicles",
  "sort_field": "idx",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/vehicles/doctype/vehicle_panel_job/vehicle_panel_job.json
+++ b/erpnext/vehicles/doctype/vehicle_panel_job/vehicle_panel_job.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:job_name",
  "creation": "2022-10-19 16:26:47.511882",
@@ -27,10 +28,12 @@
    "reqd": 1
   }
  ],
- "modified": "2022-11-30 16:37:36.319662",
+ "links": [],
+ "modified": "2023-10-31 15:29:24.147137",
  "modified_by": "Administrator",
  "module": "Vehicles",
  "name": "Vehicle Panel Job",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -63,6 +66,15 @@
    "print": 1,
    "read": 1,
    "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
    "role": "Vehicle Manager",
    "share": 1
   }
@@ -71,5 +83,6 @@
  "restrict_to_domain": "Vehicles",
  "sort_field": "idx",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/vehicles/doctype/vehicle_panel_side/vehicle_panel_side.json
+++ b/erpnext/vehicles/doctype/vehicle_panel_side/vehicle_panel_side.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:panel_side_name",
  "creation": "2022-10-19 16:24:54.054939",
@@ -18,10 +19,12 @@
    "unique": 1
   }
  ],
- "modified": "2022-11-30 16:37:32.323011",
+ "links": [],
+ "modified": "2023-10-31 15:29:41.560210",
  "modified_by": "Administrator",
  "module": "Vehicles",
  "name": "Vehicle Panel Side",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -54,6 +57,15 @@
    "print": 1,
    "read": 1,
    "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
    "role": "Vehicle Manager",
    "share": 1
   }
@@ -62,5 +74,6 @@
  "restrict_to_domain": "Vehicles",
  "sort_field": "idx",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/vehicles/doctype/vehicle_service_receipt/vehicle_service_receipt.json
+++ b/erpnext/vehicles/doctype/vehicle_service_receipt/vehicle_service_receipt.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "autoname": "naming_series:",
  "creation": "2022-04-03 21:45:44.776492",
@@ -380,10 +381,12 @@
  "icon": "fa fa-file-text",
  "image_field": "image",
  "is_submittable": 1,
- "modified": "2023-03-09 15:56:50.520911",
+ "links": [],
+ "modified": "2023-10-31 15:27:16.307369",
  "modified_by": "Administrator",
  "module": "Vehicles",
  "name": "Vehicle Service Receipt",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -400,6 +403,15 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User (Read Only)",
+   "share": 1
   },
   {
    "email": 1,
@@ -434,6 +446,7 @@
  "show_name_in_global_search": 1,
  "sort_field": "posting_date",
  "sort_order": "DESC",
+ "states": [],
  "timeline_field": "customer",
  "title_field": "title",
  "track_changes": 1,

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_task_row.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_task_row.html
@@ -1,7 +1,8 @@
 <tr>
 	<td class="text-nowrap">
 		<div>
-			<a href="{{ frappe.utils.get_form_link('Project', doc.project) }}" class="show-project" data-project="{{ doc.project }}" target="_blank">
+			<a href="{{ frappe.utils.get_form_link('Project', doc.project) }}" class="show-project"
+				data-project="{{ doc.project }}" target="_blank">
 				{{ doc.project }}
 			</a>
 		</div>
@@ -11,17 +12,17 @@
 	<td>
 		<div>
 			{% if doc.applies_to_variant_of_name %}
-				{{ doc.applies_to_variant_of_name }}
+			{{ doc.applies_to_variant_of_name }}
 			{% else %}
-				{{ doc.applies_to_item_name }}
+			{{ doc.applies_to_item_name }}
 			{% endif %}
 		</div>
 		<div>
 			<a href="{{ frappe.utils.get_form_link('Vehicle', doc.applies_to_vehicle) }}" target="_blank">
 				{% if doc.vehicle_license_plate %}
-					{{ doc.vehicle_license_plate }}
+				{{ doc.vehicle_license_plate }}
 				{% else %}
-					{{ doc.vehicle_chassis_no }}
+				{{ doc.vehicle_chassis_no }}
 				{% endif %}
 			</a>
 		</div>
@@ -39,7 +40,7 @@
 	{% if doc.start_dt %}
 		<div>{{ frappe.datetime.str_to_user(doc.start_dt, false, true) }}</div>
 		<div>{{ moment(doc.start_dt).format('hh:mm A') }}</div>
-	{% endif %}
+		{% endif %}
 	</td>
 
 	<td class="text-center text-nowrap">
@@ -67,54 +68,54 @@
 				</svg>
 			</button>
 			<div role="menu" class="dropdown-menu dropdown-menu-right">
-				{% if doc.assigned_to_name && doc.status == "Open" %}
-					<button class="dropdown-item start_task" data-task="{{ doc.task }}">
-						{{ __("Start Task") }}
-					</button>
+				{% if doc.actions.start_task %}
+				<button class="dropdown-item start_task" data-task="{{ doc.task }}">
+					{{ __("Start Task") }}
+				</button>
 				{% endif %}
 
-				{% if ["On Hold", "Working", "Pending Review"].includes(doc.status) %}
-					<button class="dropdown-item complete_task" data-task="{{ doc.task }}">
-						{{ __("Complete Task") }}
-					</button>
+				{% if doc.actions.complete_task %}
+				<button class="dropdown-item complete_task" data-task="{{ doc.task }}">
+					{{ __("Complete Task") }}
+				</button>
 				{% endif %}
 
-				{% if doc.status == "Working" %}
-					<button class="dropdown-item pause_task" data-task="{{ doc.task }}">
-						{{ __("Pause Task") }}
-					</button>
+				{% if doc.actions.pause_task %}
+				<button class="dropdown-item pause_task" data-task="{{ doc.task }}">
+					{{ __("Pause Task") }}
+				</button>
 				{% endif %}
 
-				{% if ["On Hold", "Completed"].includes(doc.status) && !doc.ready_to_close %}
-					<button class="dropdown-item resume_task" data-task="{{ doc.task }}">
-						{{ __("Resume Task") }}
-					</button>
+				{% if doc.actions.resume_task %}
+				<button class="dropdown-item resume_task" data-task="{{ doc.task }}">
+					{{ __("Resume Task") }}
+				</button>
 				{% endif %}
 
 				<div class="dropdown-divider"></div>
 
-				{% if (!doc.assigned_to_name) { %}
+				{% if (doc.actions.assign_technician) { %}
 					<button class="dropdown-item assign_technician" data-task="{{ doc.task }}">
 						{{ __("Assign Technician") }}
 					</button>
-				{% } else if (!["Completed", "Cancelled"].includes(doc.status)) { %}
+				{% } else if (doc.actions.reassign_technician) { %}
 					<button class="dropdown-item reassign_technician" data-task="{{ doc.task }}">
 						{{ __("Re-Assign Technician") }}
 					</button>
-				{% } %}
+				{% endif %}
 
 				<div class="dropdown-divider"></div>
 
-				{% if doc.status != "Completed" %}
-					<button class="dropdown-item edit_task" data-task="{{ doc.task }}">
-						{{ __("Edit Task") }}
-					</button>
+				{% if doc.actions.edit_task %}
+				<button class="dropdown-item edit_task" data-task="{{ doc.task }}">
+					{{ __("Edit Task") }}
+				</button>
 				{% endif %}
 
-				{% if doc.status == "Open" %}
-					<button class="dropdown-item cancel_task" data-task="{{ doc.task }}">
-						{{ __("Cancel Task") }}
-					</button>
+				{% if doc.actions.cancel_task %}
+				<button class="dropdown-item cancel_task" data-task="{{ doc.task }}">
+					{{ __("Cancel Task") }}
+				</button>
 				{% endif %}
 			</div>
 		</div>

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_task_row.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_task_row.html
@@ -12,17 +12,17 @@
 	<td>
 		<div>
 			{% if doc.applies_to_variant_of_name %}
-			{{ doc.applies_to_variant_of_name }}
+				{{ doc.applies_to_variant_of_name }}
 			{% else %}
-			{{ doc.applies_to_item_name }}
+				{{ doc.applies_to_item_name }}
 			{% endif %}
 		</div>
 		<div>
 			<a href="{{ frappe.utils.get_form_link('Vehicle', doc.applies_to_vehicle) }}" target="_blank">
 				{% if doc.vehicle_license_plate %}
-				{{ doc.vehicle_license_plate }}
+					{{ doc.vehicle_license_plate }}
 				{% else %}
-				{{ doc.vehicle_chassis_no }}
+					{{ doc.vehicle_chassis_no }}
 				{% endif %}
 			</a>
 		</div>
@@ -40,7 +40,7 @@
 	{% if doc.start_dt %}
 		<div>{{ frappe.datetime.str_to_user(doc.start_dt, false, true) }}</div>
 		<div>{{ moment(doc.start_dt).format('hh:mm A') }}</div>
-		{% endif %}
+	{% endif %}
 	</td>
 
 	<td class="text-center text-nowrap">
@@ -69,27 +69,27 @@
 			</button>
 			<div role="menu" class="dropdown-menu dropdown-menu-right">
 				{% if doc.actions.start_task %}
-				<button class="dropdown-item start_task" data-task="{{ doc.task }}">
-					{{ __("Start Task") }}
-				</button>
+					<button class="dropdown-item start_task" data-task="{{ doc.task }}">
+						{{ __("Start Task") }}
+					</button>
 				{% endif %}
 
 				{% if doc.actions.complete_task %}
-				<button class="dropdown-item complete_task" data-task="{{ doc.task }}">
-					{{ __("Complete Task") }}
-				</button>
+					<button class="dropdown-item complete_task" data-task="{{ doc.task }}">
+						{{ __("Complete Task") }}
+					</button>
 				{% endif %}
 
 				{% if doc.actions.pause_task %}
-				<button class="dropdown-item pause_task" data-task="{{ doc.task }}">
-					{{ __("Pause Task") }}
-				</button>
+					<button class="dropdown-item pause_task" data-task="{{ doc.task }}">
+						{{ __("Pause Task") }}
+					</button>
 				{% endif %}
 
 				{% if doc.actions.resume_task %}
-				<button class="dropdown-item resume_task" data-task="{{ doc.task }}">
-					{{ __("Resume Task") }}
-				</button>
+					<button class="dropdown-item resume_task" data-task="{{ doc.task }}">
+						{{ __("Resume Task") }}
+					</button>
 				{% endif %}
 
 				<div class="dropdown-divider"></div>
@@ -107,15 +107,15 @@
 				<div class="dropdown-divider"></div>
 
 				{% if doc.actions.edit_task %}
-				<button class="dropdown-item edit_task" data-task="{{ doc.task }}">
-					{{ __("Edit Task") }}
-				</button>
+					<button class="dropdown-item edit_task" data-task="{{ doc.task }}">
+						{{ __("Edit Task") }}
+					</button>
 				{% endif %}
 
 				{% if doc.actions.cancel_task %}
-				<button class="dropdown-item cancel_task" data-task="{{ doc.task }}">
-					{{ __("Cancel Task") }}
-				</button>
+					<button class="dropdown-item cancel_task" data-task="{{ doc.task }}">
+						{{ __("Cancel Task") }}
+					</button>
 				{% endif %}
 			</div>
 		</div>

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicle_row.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicle_row.html
@@ -56,26 +56,30 @@
 				</svg>
 			</button>
 			<div role="menu" class="dropdown-menu dropdown-menu-right">
-				{% if !doc.ready_to_close %}
-					{% if doc.total_tasks && doc.completed_tasks == doc.total_tasks %}
-						<button class="dropdown-item mark_as_ready" data-project="{{ doc.project }}">
-							{{ __("Mark as Ready") }}
-						</button>
-					{% endif %}
-
-					<div class="dropdown-divider"></div>
-
-					<button class="dropdown-item create_task" data-project="{{ doc.project }}">
-						{{ __("Create Task") }}
+				{% if doc.actions.mark_as_ready %}
+					<button class="dropdown-item mark_as_ready" data-project="{{ doc.project }}">
+						{{ __("Mark as Ready") }}
 					</button>
+				{% endif %}
 
-					<button class="dropdown-item create_template_tasks" data-project="{{ doc.project }}">
-						{%= __("Create Template Task") %}
-					</button>
-				{% else %}
-					<button class="dropdown-item reopen" data-project="{{ doc.project }}">
-						{{ __("Re-Open") }}
-					</button>
+				<div class="dropdown-divider"></div>
+
+				{% if doc.actions.create_task %}
+				<button class="dropdown-item create_task" data-project="{{ doc.project }}">
+					{{ __("Create Task") }}
+				</button>
+				{% endif %}
+
+				{% if doc.actions.create_template_tasks %}
+				<button class="dropdown-item create_template_tasks" data-project="{{ doc.project }}">
+					{%= __("Create Template Task") %}
+				</button>
+				{% endif %}
+
+				{% if doc.actions.reopen %}
+				<button class="dropdown-item reopen" data-project="{{ doc.project }}">
+					{{ __("Re-Open") }}
+				</button>
 				{% endif %}
 			</div>
 		</div>

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicle_row.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicle_row.html
@@ -65,21 +65,21 @@
 				<div class="dropdown-divider"></div>
 
 				{% if doc.actions.create_task %}
-				<button class="dropdown-item create_task" data-project="{{ doc.project }}">
-					{{ __("Create Task") }}
-				</button>
+					<button class="dropdown-item create_task" data-project="{{ doc.project }}">
+						{{ __("Create Task") }}
+					</button>
 				{% endif %}
 
 				{% if doc.actions.create_template_tasks %}
-				<button class="dropdown-item create_template_tasks" data-project="{{ doc.project }}">
-					{%= __("Create Template Task") %}
-				</button>
+					<button class="dropdown-item create_template_tasks" data-project="{{ doc.project }}">
+						{%= __("Create Template Task") %}
+					</button>
 				{% endif %}
 
 				{% if doc.actions.reopen %}
-				<button class="dropdown-item reopen" data-project="{{ doc.project }}">
-					{{ __("Re-Open") }}
-				</button>
+					<button class="dropdown-item reopen" data-project="{{ doc.project }}">
+						{{ __("Re-Open") }}
+					</button>
 				{% endif %}
 			</div>
 		</div>

--- a/erpnext/vehicles/page/workshop_cp/workshop_cp.js
+++ b/erpnext/vehicles/page/workshop_cp/workshop_cp.js
@@ -587,10 +587,17 @@ class WorkshopCP {
 					"fieldtype": "Link",
 					"options": "Employee",
 					"reqd": 1,
+					"get_query": function() {
+						return {
+							filters: {
+								"is_technician": 1
+							}
+						};
+					},
 					"onchange": () => {
 						let employee = dialog.get_value('employee');
 						if (employee) {
-							frappe.db.get_value("Employee", employee, ['employee_name'], (r) => {
+							frappe.db.get_value("Employee", employee, ['employee_name',], (r) => {
 								if (r) {
 									dialog.set_value('employee_name', r.employee_name);
 								}
@@ -642,6 +649,13 @@ class WorkshopCP {
 					"fieldtype": "Link",
 					"options": "Employee",
 					"default": task_data.assigned_to,
+					"get_query": function() {
+						return {
+							filters: {
+								"is_technician": 1
+							}
+						};
+					},
 					"onchange": () => {
 						let employee = dialog.get_value('employee');
 						if (employee) {

--- a/erpnext/vehicles/page/workshop_cp/workshop_cp.js
+++ b/erpnext/vehicles/page/workshop_cp/workshop_cp.js
@@ -597,7 +597,7 @@ class WorkshopCP {
 					"onchange": () => {
 						let employee = dialog.get_value('employee');
 						if (employee) {
-							frappe.db.get_value("Employee", employee, ['employee_name',], (r) => {
+							frappe.db.get_value("Employee", employee, ['employee_name'], (r) => {
 								if (r) {
 									dialog.set_value('employee_name', r.employee_name);
 								}

--- a/erpnext/vehicles/page/workshop_cp/workshop_cp.json
+++ b/erpnext/vehicles/page/workshop_cp/workshop_cp.json
@@ -4,7 +4,7 @@
  "docstatus": 0,
  "doctype": "Page",
  "idx": 0,
- "modified": "2023-08-03 17:39:54.325897",
+ "modified": "2023-10-31 15:33:05.645451",
  "modified_by": "Administrator",
  "module": "Vehicles",
  "name": "workshop-cp",
@@ -14,6 +14,9 @@
  "roles": [
   {
    "role": "Projects User"
+  },
+  {
+   "role": "Projects User (Read Only)"
   }
  ],
  "script": null,

--- a/erpnext/vehicles/page/workshop_cp/workshop_cp.py
+++ b/erpnext/vehicles/page/workshop_cp/workshop_cp.py
@@ -119,7 +119,7 @@ def set_task_action_conditions(data):
 	for d in data:
 		d.actions = {
 			"start_task": has_task_write and d.assigned_to and d.status == "Open",
-			"complete_task":has_task_write and d.status in ("On Hold", "Working", "Pending Review"),
+			"complete_task": has_task_write and d.status in ("On Hold", "Working", "Pending Review"),
 			"pause_task": has_task_write and d.status == "Working",
 			"resume_task": has_task_write and d.status in ("On Hold", "Completed") and not d.ready_to_close,
 			"assign_technician": has_task_write and not d.assigned_to,

--- a/erpnext/vehicles/workspace/vehicles/vehicles.json
+++ b/erpnext/vehicles/workspace/vehicles/vehicles.json
@@ -19,6 +19,7 @@
  ],
  "content": "[{\"id\":\"riX7CSbNat\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Automotive / Vehicles Module</b></span>\",\"col\":12}},{\"id\":\"546Lzvak4b\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Vehicle Booking Order\",\"col\":3}},{\"id\":\"dbat--tnir\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Repair Order\",\"col\":3}},{\"id\":\"ANqgLGC8Ln\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Vehicle Quotation\",\"col\":3}},{\"id\":\"ROIfJ5JdUH\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Appointment\",\"col\":3}},{\"id\":\"iZz7y3hpHS\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Vehicle Stock\",\"col\":3}},{\"id\":\"mDVA6lR0Qq\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Vehicle Tracking Sheet\",\"col\":3}},{\"id\":\"6JI7J63jXX\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Opportunity\",\"col\":3}},{\"id\":\"0XDNkEKMUa\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Appointment Sheet\",\"col\":3}},{\"id\":\"NVuLIq2HoU\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"mCJ5t8BwIx\",\"type\":\"chart\",\"data\":{\"chart_name\":\"Booking Status Summary\",\"col\":6}},{\"id\":\"x2XOTSjBBA\",\"type\":\"chart\",\"data\":{\"chart_name\":\"Top Vehicle Models\",\"col\":6}},{\"id\":\"mZfcY6_99d\",\"type\":\"chart\",\"data\":{\"chart_name\":\"Vehicle Booking Timeline\",\"col\":6}},{\"id\":\"bKGNU7VqIR\",\"type\":\"chart\",\"data\":{\"chart_name\":\"Vehicle Delivery Timeline\",\"col\":6}},{\"id\":\"EgliZkHFtN\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"A59YUxp1KJ\",\"type\":\"card\",\"data\":{\"card_name\":\"Booking\",\"col\":3}},{\"id\":\"axV6devO5G\",\"type\":\"card\",\"data\":{\"card_name\":\"Pre Sales\",\"col\":3}},{\"id\":\"mvl6xOaQkl\",\"type\":\"card\",\"data\":{\"card_name\":\"Stock\",\"col\":3}},{\"id\":\"J_HxIq5hLV\",\"type\":\"card\",\"data\":{\"card_name\":\"Vehicle Service\",\"col\":3}},{\"id\":\"9DFljhCz2G\",\"type\":\"card\",\"data\":{\"card_name\":\"Vehicle Pre Service\",\"col\":3}},{\"id\":\"3cHnBhXsas\",\"type\":\"card\",\"data\":{\"card_name\":\"Vehicle Registration\",\"col\":3}},{\"id\":\"4khyNm-xuQ\",\"type\":\"card\",\"data\":{\"card_name\":\"Vehicle Documents\",\"col\":3}},{\"id\":\"Lq3zrMyIiM\",\"type\":\"card\",\"data\":{\"card_name\":\"Reports\",\"col\":3}},{\"id\":\"e5KQiwWna_\",\"type\":\"card\",\"data\":{\"card_name\":\"Vehicle Sales Masters\",\"col\":3}},{\"id\":\"Z4SiZNziWM\",\"type\":\"card\",\"data\":{\"card_name\":\"Vehicle Service Masters\",\"col\":3}},{\"id\":\"FCoHVejSLu\",\"type\":\"card\",\"data\":{\"card_name\":\"Settings\",\"col\":3}}]",
  "creation": "2022-11-16 04:31:56.203759",
+ "custom_blocks": [],
  "docstatus": 0,
  "doctype": "Workspace",
  "hide_custom": 0,
@@ -666,7 +667,7 @@
    "type": "Link"
   }
  ],
- "modified": "2023-09-21 14:15:32.473953",
+ "modified": "2023-10-31 15:33:30.650497",
  "modified_by": "Administrator",
  "module": "Vehicles",
  "name": "Vehicles",
@@ -688,6 +689,9 @@
   },
   {
    "role": "Projects User"
+  },
+  {
+   "role": "Projects User (Read Only)"
   },
   {
    "role": "Accounts User"


### PR DESCRIPTION
closes: https://github.com/ParaLogicTech/erpnext/issues/279
closes : https://github.com/ParaLogicTech/erpnext/issues/276

**Employee:** 
- Add "Is Technician" Checkbox for employees to distinguish technical roles.

**Project User (Read Only) Permission:**
 **"Project User (Read Only)"** permission for the following doctype:

- Employee
- Maintenance Schedule
- Activity Type
- Project
- Project Status
- Project Template
- Project Template Category
- Project Type
- Project Workshop
- Task
- Company
- Vehicle Delivery
- Vehicle Gate Pass
- Vehicle Log
- Vehicle Panel
- Vehicle Panel Job
- Vehicle Panel Side
- Vehicle Service Receipt

Only timesheets should have the permissions, including 'Create,' 'Read,' 'Write,' 'Delete,' and 'Amend,' for users with the 'Project User (Read Only)' role.

**Task Tab:**
-  Permissions for the "Write Task" on  actions button.
- Add a filter for technicians on the Employee field on "Assign Technician" and "Reassign Technician" buttons.

**Vehicle Tab:**
- Review and refine permissions for the "Create Task" action button.
- Review permissions for the "Write Project" on actions button.