### PR TITLE
fix: Cancelled Employee Advance Error in Salary Slip

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1614,15 +1614,18 @@ class SalesInvoice(SellingController):
 				frappe.throw(_("Applicable Commission Item is not set for {0}").format(
 					frappe.get_desk_link("Item", item_code)
 				))
+
+			vbo_exists = False
 			for row in self.items:
 				if row.vehicle_booking_order == vbo:
-					frappe.throw(_("An item for {0} already exists")
-				  .format(frappe.get_desk_link('Vehicle Booking Order', vbo)))
+					vbo_exists = True
+					break
 
-			row = self.append("items", frappe.new_doc("Sales Invoice Item"))
-			row.item_code = applicable_commission_item
-			row.vehicle_booking_order = vbo
-			row.qty = 1
+			if not vbo_exists:
+				row = self.append("items", frappe.new_doc("Sales Invoice Item"))
+				row.item_code = applicable_commission_item
+				row.vehicle_booking_order = vbo
+				row.qty = 1
 
 		self.set_missing_values()
 		self.calculate_taxes_and_totals()

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1602,9 +1602,22 @@ class SalesInvoice(SellingController):
 		if isinstance(vehicle_booking_orders, str):
 			vehicle_booking_orders = json.load(vehicle_booking_orders)
 
+		# remove empty row
+		if self.get('items') and not self.items[0].item_code and not self.items[0].item_name:
+			self.remove(self.items[0])
+
 		for vbo in vehicle_booking_orders:
 			item_code = frappe.db.get_value("Vehicle Booking Order", vbo, "item_code")
+
 			applicable_commission_item = frappe.get_cached_value("Item", item_code, "applicable_commission_item")
+			if not applicable_commission_item:
+				frappe.throw(_("Applicable Commission Item is not set for {0}").format(
+					frappe.get_desk_link("Item", item_code)
+				))
+			for row in self.items:
+				if row.vehicle_booking_order == vbo:
+					frappe.throw(_("An item for {0} already exists")
+				  .format(frappe.get_desk_link('Vehicle Booking Order', vbo)))
 
 			row = self.append("items", frappe.new_doc("Sales Invoice Item"))
 			row.item_code = applicable_commission_item

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -593,7 +593,7 @@ class calculate_taxes_and_totals(object):
 		if not tax.get('exclude_from_item_tax_amount') and tax.charge_type != "Actual":
 			item.item_taxes += current_tax_amount
 
-		key = item.item_code or item.item_name
+		key = item.item_code or item.item_name or ""
 		item_wise_tax_amount = current_tax_amount*self.doc.conversion_rate
 		if tax.item_wise_tax_detail.get(key):
 			item_wise_tax_amount += tax.item_wise_tax_detail[key][1]
@@ -1120,7 +1120,7 @@ def get_itemised_tax(taxes, with_tax_account=False):
 def get_itemised_taxable_amount(items):
 	itemised_taxable_amount = frappe._dict()
 	for item in items:
-		item_code = item.item_code or item.item_name
+		item_code = item.item_code or item.item_name or ""
 		itemised_taxable_amount.setdefault(item_code, 0)
 		itemised_taxable_amount[item_code] += item.taxable_amount
 
@@ -1130,7 +1130,7 @@ def get_itemised_taxable_amount(items):
 def get_itemised_net_amount(items):
 	itemised_net_amount = frappe._dict()
 	for item in items:
-		item_code = item.item_code or item.item_name
+		item_code = item.item_code or item.item_name or ""
 		itemised_net_amount.setdefault(item_code, 0)
 		itemised_net_amount[item_code] += item.net_amount
 
@@ -1140,7 +1140,7 @@ def get_itemised_net_amount(items):
 def get_itemised_qty(items):
 	itemised_qty = frappe._dict()
 	for item in items:
-		item_code = item.item_code or item.item_name
+		item_code = item.item_code or item.item_name or ""
 		itemised_qty.setdefault(item_code, 0)
 		itemised_qty[item_code] += item.qty
 

--- a/erpnext/domains/vehicles.py
+++ b/erpnext/domains/vehicles.py
@@ -321,6 +321,8 @@ item_fields = [
 	{"label": "Vehicle Allocation Required From Delivery Period", "fieldname": "vehicle_allocation_required_from_delivery_period",
 		"fieldtype": "Link", "options": "Vehicle Allocation Period",
 		"insert_after": "vehicle_allocation_required", "depends_on": "vehicle_allocation_required", "ignore_user_permissions": 1},
+	{"fieldname": "cb_commission_item", "fieldtype": "Column Break", "insert_after": "applicable_to_all"},
+	{"label": "Applicable Commission Item", "fieldname": "applicable_commission_item", "fieldtype": "Link", "options": "Items", "insert_after": "cb_commission_item"},
 ]
 
 # Set Translatable = 0

--- a/erpnext/domains/vehicles.py
+++ b/erpnext/domains/vehicles.py
@@ -322,7 +322,8 @@ item_fields = [
 		"fieldtype": "Link", "options": "Vehicle Allocation Period",
 		"insert_after": "vehicle_allocation_required", "depends_on": "vehicle_allocation_required", "ignore_user_permissions": 1},
 	{"fieldname": "cb_commission_item", "fieldtype": "Column Break", "insert_after": "applicable_to_all"},
-	{"label": "Applicable Commission Item", "fieldname": "applicable_commission_item", "fieldtype": "Link", "options": "Items", "insert_after": "cb_commission_item"},
+	{"label": "Applicable Commission Item", "fieldname": "applicable_commission_item", "fieldtype": "Link","options": "Items",
+		"insert_after": "cb_commission_item"},
 ]
 
 # Set Translatable = 0

--- a/erpnext/hr/doctype/employee_advance/employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.py
@@ -5,7 +5,7 @@
 import frappe
 import erpnext
 from frappe import _
-from frappe.utils import flt, nowdate
+from frappe.utils import flt, nowdate, cint
 from erpnext.controllers.status_updater import StatusUpdater
 from six import string_types
 import json
@@ -133,6 +133,8 @@ def make_bank_entry(dt, dn, is_advance_return=False):
 
 	if not frappe.has_permission("Journal Entry", "write"):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
+	is_advance_return = cint(is_advance_return)
 
 	doc = frappe.get_doc(dt, dn)
 	payment_account = get_default_bank_cash_account(doc.company, account_type="Cash",

--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -41,6 +41,7 @@ class SalarySlip(TransactionBase):
 
 	def before_validate_links(self):
 		self.loans = []
+		self.advances = []
 
 	def validate(self):
 		self.status = self.get_status()

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -817,7 +817,7 @@ erpnext.patches.v14_0.trim_packing_slip_table
 execute:frappe.delete_doc_if_exists("Report", "Batch Balance")
 execute:frappe.delete_doc_if_exists("Report", "Warehouse wise Item Balance Age and Value")
 execute:frappe.delete_doc_if_exists("Custom Field", "Customer-reference")
-erpnext.patches.v12_0.resetup_vehicle_domain #12-01-2023 #02-02-2023 #07-03-2023
+erpnext.patches.v12_0.resetup_vehicle_domain #12-01-2023 #02-02-2023 #07-03-2023 #26-10-2023
 erpnext.patches.v12_0.update_total_panel_qty_in_project
 execute:frappe.delete_doc_if_exists("Custom Field", "Customer_date_of_birth")
 erpnext.patches.v12_0.update_detailed_sales_data_in_project

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -817,7 +817,7 @@ erpnext.patches.v14_0.trim_packing_slip_table
 execute:frappe.delete_doc_if_exists("Report", "Batch Balance")
 execute:frappe.delete_doc_if_exists("Report", "Warehouse wise Item Balance Age and Value")
 execute:frappe.delete_doc_if_exists("Custom Field", "Customer-reference")
-erpnext.patches.v12_0.resetup_vehicle_domain #12-01-2023 #02-02-2023 #07-03-2023 #26-10-2023
+erpnext.patches.v12_0.resetup_vehicle_domain #12-01-2023 #02-02-2023 #07-03-2023 #27-10-2023
 erpnext.patches.v12_0.update_total_panel_qty_in_project
 execute:frappe.delete_doc_if_exists("Custom Field", "Customer_date_of_birth")
 erpnext.patches.v12_0.update_detailed_sales_data_in_project

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -371,7 +371,7 @@ $.extend(erpnext.item, {
 
 		frm.set_query("applicable_commission_item", function(doc, cdt, cdn) {
 			var filters = {
-				"is_stock_item": "0"
+				"is_stock_item": 0
 			  };
 			  return erpnext.queries.item(filters);
 		});

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -369,6 +369,12 @@ $.extend(erpnext.item, {
 			}
 		});
 
+		frm.set_query("applicable_commission_item", function(doc, cdt, cdn) {
+			return {
+				filters: { 'is_stock_item' : 0}
+			};
+		});
+
 		frm.set_query("applicable_item_code", "applicable_items", function (doc, cdt, cdn) {
 			var filters = {};
 			if (!doc.__islocal) {

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -370,9 +370,10 @@ $.extend(erpnext.item, {
 		});
 
 		frm.set_query("applicable_commission_item", function(doc, cdt, cdn) {
-			return {
-				filters: { 'is_stock_item' : 0}
-			};
+			var filters = {
+				"is_stock_item": "0"
+			  };
+			  return erpnext.queries.item(filters);
 		});
 
 		frm.set_query("applicable_item_code", "applicable_items", function (doc, cdt, cdn) {

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -158,8 +158,6 @@
   "applicable_to_section",
   "applicable_to",
   "applicable_to_all",
-  "column_break_uabq2",
-  "applicable_commission_item",
   "applicable_items_section",
   "applicable_items",
   "website_tab",
@@ -1357,16 +1355,6 @@
    "fieldname": "skip_transfer_for_manufacture",
    "fieldtype": "Check",
    "label": "Skip Transfer for Manufacture"
-  },
-  {
-   "fieldname": "column_break_uabq2",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "applicable_commission_item",
-   "fieldtype": "Link",
-   "label": "Applicable Commission Item",
-   "options": "Item"
   }
  ],
  "has_web_view": 1,
@@ -1374,7 +1362,7 @@
  "idx": 2,
  "image_field": "image",
  "links": [],
- "modified": "2023-10-13 16:21:13.181423",
+ "modified": "2023-10-26 17:16:40.063924",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -158,6 +158,8 @@
   "applicable_to_section",
   "applicable_to",
   "applicable_to_all",
+  "column_break_uabq2",
+  "applicable_commission_item",
   "applicable_items_section",
   "applicable_items",
   "website_tab",
@@ -1355,6 +1357,16 @@
    "fieldname": "skip_transfer_for_manufacture",
    "fieldtype": "Check",
    "label": "Skip Transfer for Manufacture"
+  },
+  {
+   "fieldname": "column_break_uabq2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "applicable_commission_item",
+   "fieldtype": "Link",
+   "label": "Applicable Commission Item",
+   "options": "Item"
   }
  ],
  "has_web_view": 1,
@@ -1362,7 +1374,7 @@
  "idx": 2,
  "image_field": "image",
  "links": [],
- "modified": "2023-10-24 14:21:42.613467",
+ "modified": "2023-10-13 16:21:13.181423",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/vehicles/doctype/vehicle_booking_order/vehicle_booking_order.py
+++ b/erpnext/vehicles/doctype/vehicle_booking_order/vehicle_booking_order.py
@@ -974,6 +974,24 @@ def make_pdi_repair_order(source):
 	return target
 
 
+@frappe.whitelist()
+def get_vbos_for_sales_invoice(applies_to_item, from_date, to_date):
+
+	vbo_data = frappe.db.sql("""
+		SELECT name
+		FROM `tabVehicle Booking Order`
+		WHERE item_code = %(applies_to_item)s
+				AND delivery_status = 'Delivered'
+				AND transaction_date >= %(from_date)s
+				AND transaction_date <= %(to_date)s
+		""", {'applies_to_item': applies_to_item, 'from_date': from_date, 'to_date': to_date})
+
+	if not vbo_data:
+		frappe.throw("No vehicle booking order(s) have been located.")
+
+	return vbo_data
+
+
 def check_if_doc_exists(doctype, vehicle_booking_order, filters=None):
 	filter_args = filters or {}
 	filters = {"vehicle_booking_order": vehicle_booking_order, "docstatus": ["<", 2]}

--- a/erpnext/vehicles/doctype/vehicle_booking_order/vehicle_booking_order.py
+++ b/erpnext/vehicles/doctype/vehicle_booking_order/vehicle_booking_order.py
@@ -975,21 +975,33 @@ def make_pdi_repair_order(source):
 
 
 @frappe.whitelist()
-def get_vbos_for_sales_invoice(applies_to_item, from_date, to_date):
+def get_vbos_for_sales_invoice(from_date, to_date, item_code=None):
+    if not from_date or not to_date:
+        frappe.throw(_("From Date and To Date is mandatory"))
 
-	vbo_data = frappe.db.sql("""
-		SELECT name
-		FROM `tabVehicle Booking Order`
-		WHERE item_code = %(applies_to_item)s
-				AND delivery_status = 'Delivered'
-				AND transaction_date >= %(from_date)s
-				AND transaction_date <= %(to_date)s
-		""", {'applies_to_item': applies_to_item, 'from_date': from_date, 'to_date': to_date})
+    item_condition = ""
 
-	if not vbo_data:
-		frappe.throw("No vehicle booking order(s) have been located.")
+    if item_code:
+        if cint(frappe.db.get_value("Item", item_code, 'has_variants')):
+            item_condition = "AND i.variant_of = %(item_code)s"
+        else:
+            item_condition = "AND i.item_code = %(item_code)s"
 
-	return vbo_data
+    vbo_names = frappe.db.sql_list("""
+        SELECT vbo.name
+        FROM `tabVehicle Booking Order` vbo
+        INNER JOIN `tabItem` i ON i.item_code = vbo.item_code
+        WHERE vbo.delivery_status = 'Delivered'
+            AND vbo.vehicle_delivered_date >= %(from_date)s
+            AND vbo.vehicle_delivered_date <= %(to_date)s
+            AND vbo.docstatus = 1
+            {item_condition}
+        """.format(item_condition=item_condition), {'item_code': item_code, 'from_date': from_date, 'to_date': to_date},as_dict =1 )
+
+    if not vbo_names:
+        frappe.throw("No Vehicle Booking Orders found")
+
+    return vbo_names
 
 
 def check_if_doc_exists(doctype, vehicle_booking_order, filters=None):

--- a/erpnext/vehicles/doctype/vehicle_booking_order/vehicle_booking_order.py
+++ b/erpnext/vehicles/doctype/vehicle_booking_order/vehicle_booking_order.py
@@ -996,10 +996,10 @@ def get_vbos_for_sales_invoice(from_date, to_date, item_code=None):
             AND vbo.vehicle_delivered_date <= %(to_date)s
             AND vbo.docstatus = 1
             {item_condition}
-        """.format(item_condition=item_condition), {'item_code': item_code, 'from_date': from_date, 'to_date': to_date},as_dict =1 )
+        """.format(item_condition = item_condition), {'item_code': item_code, 'from_date': from_date, 'to_date': to_date}, as_dict =1)
 
     if not vbo_names:
-        frappe.throw("No Vehicle Booking Orders found")
+        frappe.throw(_("No Vehicle Booking Orders found"))
 
     return vbo_names
 

--- a/erpnext/vehicles/doctype/vehicle_booking_order/vehicle_booking_order.py
+++ b/erpnext/vehicles/doctype/vehicle_booking_order/vehicle_booking_order.py
@@ -996,7 +996,7 @@ def get_vbos_for_sales_invoice(from_date, to_date, item_code=None):
             AND vbo.vehicle_delivered_date <= %(to_date)s
             AND vbo.docstatus = 1
             {item_condition}
-        """.format(item_condition = item_condition), {'item_code': item_code, 'from_date': from_date, 'to_date': to_date}, as_dict =1)
+        """.format(item_condition=item_condition), {'item_code': item_code, 'from_date': from_date, 'to_date': to_date}, as_dict=1)
 
     if not vbo_names:
         frappe.throw(_("No Vehicle Booking Orders found"))


### PR DESCRIPTION
closes: https://github.com/ParaLogicTech/erpnext/issues/275

If an employee advance linked with a salary is canceled and the user wants to remove the employee advance  from the salary slip using the update salary slip button, an error message is displayed instead of removing the corresponding row.