### PR TITLE
fix: Cancelled Employee Advance Error in Salary Slip

### DIFF
--- a/erpnext/hr/doctype/employee_advance/employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.py
@@ -5,7 +5,7 @@
 import frappe
 import erpnext
 from frappe import _
-from frappe.utils import flt, nowdate
+from frappe.utils import flt, nowdate, cint
 from erpnext.controllers.status_updater import StatusUpdater
 from six import string_types
 import json
@@ -133,6 +133,8 @@ def make_bank_entry(dt, dn, is_advance_return=False):
 
 	if not frappe.has_permission("Journal Entry", "write"):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
+	is_advance_return = cint(is_advance_return)
 
 	doc = frappe.get_doc(dt, dn)
 	payment_account = get_default_bank_cash_account(doc.company, account_type="Cash",

--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -41,6 +41,7 @@ class SalarySlip(TransactionBase):
 
 	def before_validate_links(self):
 		self.loans = []
+		self.advances = []
 
 	def validate(self):
 		self.status = self.get_status()


### PR DESCRIPTION
closes : https://github.com/ParaLogicTech/erpnext/issues/275


- If an employee advance linked with a salary is canceled and the user wants to remove the employee advance  from the salary slip using the update salary slip button, an error message is displayed instead of removing the corresponding row.