### PR TITLE
feat(Work Order): Actual Start/End Date handling for Disabled Time Logs

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -53,7 +53,13 @@
   "wip_warehouse",
   "column_break_sd2ta",
   "material_consumption_required",
-  "material_transfer_required"
+  "material_transfer_required",
+  "section_break_rwkxt",
+  "planned_start_dt",
+  "actual_start_dt",
+  "column_break_p41ok",
+  "planned_end_dt",
+  "actual_end_dt"
  ],
  "fields": [
   {
@@ -379,12 +385,45 @@
    "fieldtype": "Check",
    "label": "Transfer Materials against Job Card",
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_rwkxt",
+   "fieldtype": "Section Break",
+   "label": "Planning"
+  },
+  {
+   "fieldname": "planned_start_dt",
+   "fieldtype": "Datetime",
+   "label": "Planned Start Date/Time"
+  },
+  {
+   "fieldname": "actual_start_dt",
+   "fieldtype": "Datetime",
+   "label": "Actual Start Date/Time",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_p41ok",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "planned_end_dt",
+   "fieldtype": "Datetime",
+   "label": "Planned End Date/Time"
+  },
+  {
+   "fieldname": "actual_end_dt",
+   "fieldtype": "Datetime",
+   "label": "Actual End Date/Time",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "is_calendar_and_gantt": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-11-16 01:40:22.568424",
+ "modified": "2023-11-20 18:03:46.538166",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -19,6 +19,9 @@ class JobCard(Document):
 		self.validate_operation_id()
 		self.set_status()
 
+	def before_submit(self):
+		self.set_actual_dates()
+
 	def on_submit(self):
 		self.validate_job_card()
 		self.update_work_order()
@@ -227,6 +230,12 @@ class JobCard(Document):
 		if stock_entry:
 			frappe.get_doc("Stock Entry", stock_entry).cancel()
 
+	def set_actual_dates(self):
+		if self.time_logs:
+			self.actual_start_dt = min(get_datetime(d.from_time) for d in self.time_logs)
+			self.actual_end_dt = max(get_datetime(d.to_time) for d in self.time_logs)
+		else:
+			self.actual_start_dt = self.actual_end_dt = get_datetime()
 
 @frappe.whitelist()
 def get_operation_details(work_order, operation):

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -378,26 +378,16 @@ class WorkOrder(StatusUpdater):
 			operation_data = frappe.db.sql("""
 				SELECT operation_id,
 					sum(total_time_in_mins) as time_in_mins,
-					sum(total_completed_qty) as completed_qty
+					sum(total_completed_qty) as completed_qty,
+					min(actual_start_dt) as start_time,
+					max(actual_end_dt) as end_time
 				FROM `tabJob Card`
 				WHERE docstatus = 1 AND work_order = %s
 				GROUP BY operation_id
 			""", self.name, as_dict=1)
 
-			operation_time_data = frappe.db.sql("""
-				SELECT jc.operation_id,
-					min(from_time) as start_time,
-					max(to_time) as end_time
-				FROM `tabJob Card Time Log` jctl
-				INNER JOIN `tabJob Card` jc ON jc.name = jctl.parent
-				WHERE jc.docstatus = 1 AND jc.work_order = %s
-				GROUP BY operation_id
-			""", self.name, as_dict=1)
-
 			for d in operation_data:
 				operation_data_map.setdefault(d.operation_id, d)
-			for d in operation_time_data:
-				operation_data_map.setdefault(d.operation_id, {}).update(d)
 
 		min_production_qty = flt(self.get_min_qty(self.producible_qty), self.precision("qty"))
 


### PR DESCRIPTION
closes https://github.com/ParaLogicTech/erpnext/issues/293

#### Skipped Part
Set Work Order's Planned Start Date as min of Planned Start Date/Time in Job Card on on_update and on_trash