### PR TITLE
feat(Workshop CP): Add Service Advisor Filter and Column (in Vehicle)

### DIFF
--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -494,7 +494,7 @@
  "is_calendar_and_gantt": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2023-10-31 17:15:25.721671",
+ "modified": "2023-11-22 17:35:28.831291",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",
@@ -510,8 +510,7 @@
    "read": 1,
    "report": 1,
    "role": "Projects User",
-   "share": 1,
-   "write": 1
+   "share": 1
   },
   {
    "email": 1,

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_task_row.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_task_row.html
@@ -60,8 +60,7 @@
 		<span class="indicator {{ doc.task_status_color }}">{{ doc.status }}</span>
 	</td>
 
-	<td class="text-center text-nowrap actions-button-column">
-	{% if doc && Object.values(doc.actions).some(action => action) %}
+	<td class="text-center text-nowrap actions-button-column-tasks">
 		<div class="inner-group-button show">
 			<button type="button" class="btn btn-default btn-sm" data-toggle="dropdown">Actions
 				<svg class="icon icon-xs">
@@ -120,6 +119,5 @@
 				{% endif %}
 			</div>
 		</div>
-	{% endif %}
 	</td>
 </tr>

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_tasks.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_tasks.html
@@ -13,7 +13,7 @@
 						<th style="width:5%" class="text-center">{%= __("Elapsed") %}<br>({%= __("Hrs") %})</th>
 						<th style="width:10%">{%= __("Technician") %}</th>
 						<th style="width:8%">{%= __("Status") %}</th>
-						<th style="width:5%"></th>
+						<th style="width:5%" class="actions-button-column-tasks"></th>
 					</tr>
 				</thead>
 				<tbody></tbody>

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicle_row.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicle_row.html
@@ -30,6 +30,8 @@
 
 	<td>{{ doc.project_name }}</td>
 
+	<td>{{ doc.service_advisor }}</td>
+
 	<td class="text-nowrap">
 		<div class="indicator {{ doc.project_status_color }}">{{ doc.tasks_status }}</div>
 		<div>

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicle_row.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicle_row.html
@@ -50,8 +50,7 @@
 		{% endif %}
 	</td>
 
-	<td class="text-center text-nowrap actions-button-column">
-	{% if Object.values(doc.actions).some(action => action) %}
+	<td class="text-center text-nowrap actions-button-column-vehicles">
 		<div class="inner-group-button show">
 			<button type="button" class="btn btn-default btn-sm" data-toggle="dropdown">Actions
 				<svg class="icon icon-xs">
@@ -86,6 +85,5 @@
 				{% endif %}
 			</div>
 		</div>
-	{% endif %}
 	</td>
 </tr>

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicles.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicles.html
@@ -8,6 +8,7 @@
 						<th style="width:12%">{%= __("Vehicle") %}</th>
 						<th style="width:15%">{%= __("Customer") %}</th>
 						<th>{%= __("Voice of Customer") %}</th>
+						<th style="width:10%">{%= __("Service Advisor") %}</th>
 						<th style="width:10%">{%= __("Status") %}</th>
 						<th style="width:8%">{%= __("Expected Delivery") %}</th>
 						<th style="width:5%"></th>

--- a/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicles.html
+++ b/erpnext/vehicles/page/workshop_cp/templates/workshop_cp_vehicles.html
@@ -11,7 +11,7 @@
 						<th style="width:10%">{%= __("Service Advisor") %}</th>
 						<th style="width:10%">{%= __("Status") %}</th>
 						<th style="width:8%">{%= __("Expected Delivery") %}</th>
-						<th style="width:5%"></th>
+						<th style="width:5%" class="actions-button-column-vehicles"></th>
 					</tr>
 				</thead>
 				<tbody></tbody>

--- a/erpnext/vehicles/page/workshop_cp/workshop_cp.js
+++ b/erpnext/vehicles/page/workshop_cp/workshop_cp.js
@@ -140,6 +140,13 @@ class WorkshopCP {
 				options: ['', 'No Tasks', 'Not Started', 'In Progress', 'On Hold', 'Completed', 'Ready']
 
 			},
+			{
+				label: "Service Advisor",
+				fieldname: "service_advisor",
+				fieldtype: "Link",
+				options: "Sales Person",
+
+			},
 		];
 
 		for (let field of filter_fields) {

--- a/erpnext/vehicles/page/workshop_cp/workshop_cp.js
+++ b/erpnext/vehicles/page/workshop_cp/workshop_cp.js
@@ -330,6 +330,22 @@ class WorkshopCP {
 
 			this.tabs.vehicles.find(".vehicle-table tbody").append(rows_html);
 		}
+
+		let have_action =  false;
+		for(let row of this.data.projects || []) {
+			if (have_action) break;
+
+			for (let action of Object.values(row?.actions || {})) {
+				if (action) {
+					have_action = true;
+					break;
+				}
+			}
+		}
+
+		if (!have_action) {
+			$('.actions-button-column-vehicles').hide();
+		}
 	}
 
 	render_tasks_tab() {
@@ -343,6 +359,22 @@ class WorkshopCP {
 			}).join("");
 
 			this.tabs.tasks.find(".task-table tbody").append(rows_html);
+		}
+
+		let have_action =  false;
+		for(let row of this.data.tasks || []) {
+			if (have_action) break;
+
+			for (let action of Object.values(row?.actions || {})) {
+				if (action) {
+					have_action = true;
+					break;
+				}
+			}
+		}
+
+		if (!have_action) {
+			$('.actions-button-column-tasks').hide();
 		}
 	}
 

--- a/erpnext/vehicles/page/workshop_cp/workshop_cp.py
+++ b/erpnext/vehicles/page/workshop_cp/workshop_cp.py
@@ -136,7 +136,7 @@ def get_projects_data(filters):
 		SELECT
 			p.name as project, p.project_name, p.project_workshop, p.tasks_status,
 			p.applies_to_variant_of, p.applies_to_variant_of_name, p.ready_to_close,
-			p.applies_to_item, p.applies_to_item_name,
+			p.applies_to_item, p.applies_to_item_name, p.service_advisor,
 			p.applies_to_vehicle, p.vehicle_chassis_no, p.vehicle_license_plate,
 			p.customer, p.customer_name,
 			p.expected_delivery_date, p.expected_delivery_time, p.vehicle_received_date, p.vehicle_delivered_date
@@ -249,6 +249,9 @@ def get_project_conditions(filters):
 		else:
 			conditions.append("p.tasks_status = %(status)s")
 			conditions.append("p.ready_to_close = 0")
+
+	if filters.get("service_advisor"):
+		conditions.append("p.service_advisor = %(service_advisor)s")
 
 	return " and ".join(conditions)
 


### PR DESCRIPTION
closes: https://github.com/ParaLogicTech/erpnext/issues/295
closes: https://github.com/ParaLogicTech/erpnext/issues/299

- Add service advisor filter in workshop-cp.
- Add service advisor column in vehicles tab.

Vehicles Tab (For Controller):
Added condition to hide the action button column when the user is identified as a **'Controller'**.

Task Tab (For Service Advisor):
Implemented a condition to hide the action button column when the user is recognized as a **'Service Advisor'.**