### PR TITLE
feat(Salary Register):Add Footer in Salary Register Report Print Format

### DIFF
--- a/erpnext/hr/report/salary_register/salary_register.html
+++ b/erpnext/hr/report/salary_register/salary_register.html
@@ -63,3 +63,22 @@
 {% } %}
 
 {{ frappe.utils.print_report_groups(original_data, print_group, print_settings.page_break_groups, _p) }}
+
+
+<div id="footer-html" class="visible-pdf" style="display: block !important; order: 1;">
+	<!-- Signature Section -->
+	<div style="margin-top: 20mm; text-align: center;">
+		<div class="clearfix">
+			<div class="pull-left" style="width: 30%; margin-top: -3.75mm; font-size: 11pt;"></div>
+			<div class="pull-left" style="width: 30%; margin-top: -3.75mm; font-size: 11pt;"></div>
+		</div>
+		<div class="clearfix">
+			<div class="pull-left" style="width: 30%; border-top: #000 1px solid">{{ ("Prepared By") }}</div>
+			<div class="pull-left" style="width: 4%; height: 1px">
+			</div>
+			<div class="pull-left" style="width: 30%; border-top: #000 1px solid">{{ ("Checked By") }}</div>
+			<div class="pull-left" style="width: 4%; height: 1px"></div>
+			<div class="pull-left" style="width: 30%; border-top: #000 1px solid">{{ ("Approved By") }}</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
closes: https://github.com/ParaLogicTech/erpnext/issues/306
Add a footer to the salary register in print format. The footer should contain the following details:

- Prepared by
- Checked by
- Approved by