### PR TITLE
[feature] ReapairOrder: (21) add repair order ready to close notifica…

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -398,10 +398,24 @@ erpnext.projects.ProjectController = class ProjectController extends crm.QuickCo
 			});
 		}
 
+		// Notification Status for Ready for Collection
+		let ready_to_close_notification_count = frappe.get_notification_count(me.frm, 'Ready to Close');
+		let ready_to_close_notification_color = ready_to_close_notification_count ? "green" : "light-gray";
+		let ready_to_close_confirmation_status = frappe.get_notification_count_str(me.frm, 'Ready to Close');
+
+		let notification_items = [
+			{
+				contents: __('Ready to Close: {0}', [ready_to_close_confirmation_status]),
+				indicator: ready_to_close_notification_color
+			},
+		]
+
+
 		me.extend_dashboard_items(status_items, billing_items);
 
 		me.add_indicator_section(__("Status"), status_items);
 		me.add_indicator_section(__("Billing"), billing_items);
+		me.add_indicator_section(__("Notification"), notification_items);
 	}
 
 	extend_dashboard_items(status_items, billing_items) { }

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -25,6 +25,7 @@ from erpnext.projects.doctype.project_status.project_status import (
 from erpnext.overrides.campaign.campaign_hooks import validate_campaign_voucher_code
 from frappe.model.meta import get_field_precision
 import json
+from frappe.core.doctype.notification_count.notification_count import get_all_notification_count
 
 
 class Project(StatusUpdaterERP):
@@ -63,6 +64,7 @@ class Project(StatusUpdaterERP):
 		self.set_onload('is_manual_project_status', is_manual_project_status(self.project_status))
 		self.set_onload('contact_nos', get_all_contact_nos('Customer', self.customer))
 		self.set_onload('task_count', self.get_task_count())
+		self.set_onload('notification_count', get_all_notification_count(self.doctype, self.name))
 
 		self.sales_data = self.get_project_sales_data(get_sales_invoice=True)
 		self.consumables_data = self.get_project_consumables_data()
@@ -1382,6 +1384,12 @@ class Project(StatusUpdaterERP):
 
 		return self._item_group_subtree[item_group]
 
+	def validate_notification(self, notification_type=None, child_doctype=None, child_name=None, throw=False):
+		if notification_type == "Ready to Close":
+			return self.ready_to_close and self.status == "To Close"
+		frappe.throw(_("Cannot send {0} notification because Repair Order status is not 'To Close'")
+					 .format(notification_type))
+
 
 def get_material_items(project, get_sales_invoice=True):
 	is_material_condition = "i.is_stock_item = 1"
@@ -1896,11 +1904,11 @@ def create_kanban_board_if_not_exists(project):
 def set_project_ready_to_close(project):
 	project = frappe.get_doc('Project', project)
 	project.check_permission('write')
-
 	project.set_ready_to_close(update=True)
 	project.set_timesheet_values(update=True)
 	project.set_status(update=True, reset=True, from_doctype="Project", action="ready_to_close")
 	project.notify_update()
+	project.run_method('notify_ready_to_close')
 
 
 @frappe.whitelist()
@@ -2819,3 +2827,5 @@ def set_warranty_claim_denied(projects, denied, reason=None):
 		doc.warranty_claim_denied = denied
 		doc.warranty_claim_denied_reason = reason
 		doc.save()
+
+

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -1386,11 +1386,30 @@ class Project(StatusUpdaterERP):
 
 	def validate_notification(self, notification_type=None, child_doctype=None, child_name=None, throw=False):
 		if notification_type == "Ready to Close":
-			if self.ready_to_close and self.status == "To Close":
-				return True
-			else:
-				frappe.throw(_("Cannot send {0} notification because Repair Order status is not 'To Close'")
-					 .format(notification_type))
+			# Notification should not be sent if document is cancelled
+			if self.docstatus == 2:
+				if throw:
+					frappe.throw(
+						_("Cannot send {0} notification because Repair Order is cancelled").format(notification_type))
+				return False
+
+			# Notification should not be sent if status is not 'To Close'
+			if self.status != "To Close":
+				if throw:
+					frappe.throw(_("Cannot send {0} notification because Repair Order status is not 'To Close'").format(
+						notification_type))
+				return False
+
+			# Notification should not be sent if not marked as ready to close
+			if not self.ready_to_close:
+				if throw:
+					frappe.throw(
+						_("Cannot send {0} notification because Repair Order is not marked as ready to close").format(
+							notification_type))
+				return False
+
+		# Return True if no conditions catch any problem
+		return True
 
 
 def get_material_items(project, get_sales_invoice=True):

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -1386,8 +1386,10 @@ class Project(StatusUpdaterERP):
 
 	def validate_notification(self, notification_type=None, child_doctype=None, child_name=None, throw=False):
 		if notification_type == "Ready to Close":
-			return self.ready_to_close and self.status == "To Close"
-		frappe.throw(_("Cannot send {0} notification because Repair Order status is not 'To Close'")
+			if self.ready_to_close and self.status == "To Close":
+				return True
+			else:
+				frappe.throw(_("Cannot send {0} notification because Repair Order status is not 'To Close'")
 					 .format(notification_type))
 
 
@@ -1907,8 +1909,8 @@ def set_project_ready_to_close(project):
 	project.set_ready_to_close(update=True)
 	project.set_timesheet_values(update=True)
 	project.set_status(update=True, reset=True, from_doctype="Project", action="ready_to_close")
-	project.notify_update()
 	project.run_method('notify_ready_to_close')
+	project.notify_update()
 
 
 @frappe.whitelist()
@@ -1926,7 +1928,6 @@ def reopen_project_status(project):
 def set_project_status(project, project_status):
 	project = frappe.get_doc('Project', project)
 	project.check_permission('write')
-
 	project.set_status(status=project_status, from_doctype="Project", action="set_status")
 	project.save()
 
@@ -2827,5 +2828,3 @@ def set_warranty_claim_denied(projects, denied, reason=None):
 		doc.warranty_claim_denied = denied
 		doc.warranty_claim_denied_reason = reason
 		doc.save()
-
-

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -22,10 +22,10 @@ from erpnext.projects.doctype.project_status.project_status import (
 	validate_project_status_for_transaction,
 	apply_project_status_transition,
 )
+from frappe.core.doctype.notification_count.notification_count import get_all_notification_count
 from erpnext.overrides.campaign.campaign_hooks import validate_campaign_voucher_code
 from frappe.model.meta import get_field_precision
 import json
-from frappe.core.doctype.notification_count.notification_count import get_all_notification_count
 
 
 class Project(StatusUpdaterERP):
@@ -1386,26 +1386,20 @@ class Project(StatusUpdaterERP):
 
 	def validate_notification(self, notification_type=None, child_doctype=None, child_name=None, throw=False):
 		if notification_type == "Ready to Close":
-			# Notification should not be sent if document is cancelled
-			if self.docstatus == 2:
-				if throw:
-					frappe.throw(
-						_("Cannot send {0} notification because Repair Order is cancelled").format(notification_type))
-				return False
-
 			# Notification should not be sent if status is not 'To Close'
 			if self.status != "To Close":
 				if throw:
-					frappe.throw(_("Cannot send {0} notification because Repair Order status is not 'To Close'").format(
-						notification_type))
+					frappe.throw(_("Cannot send {0} notification because status is not 'To Close'").format(
+						notification_type
+					))
 				return False
 
 			# Notification should not be sent if not marked as ready to close
 			if not self.ready_to_close:
 				if throw:
-					frappe.throw(
-						_("Cannot send {0} notification because Repair Order is not marked as ready to close").format(
-							notification_type))
+					frappe.throw(_("Cannot send {0} notification because ready to close is not marked").format(
+						notification_type
+					))
 				return False
 
 		# Return True if no conditions catch any problem
@@ -1925,6 +1919,7 @@ def create_kanban_board_if_not_exists(project):
 def set_project_ready_to_close(project):
 	project = frappe.get_doc('Project', project)
 	project.check_permission('write')
+
 	project.set_ready_to_close(update=True)
 	project.set_timesheet_values(update=True)
 	project.set_status(update=True, reset=True, from_doctype="Project", action="ready_to_close")
@@ -1947,6 +1942,7 @@ def reopen_project_status(project):
 def set_project_status(project, project_status):
 	project = frappe.get_doc('Project', project)
 	project.check_permission('write')
+
 	project.set_status(status=project_status, from_doctype="Project", action="set_status")
 	project.save()
 


### PR DESCRIPTION
---

## 🔔 Feature: Notification on "Ready To Close" Status

This PR introduces a feature that triggers a **notification** when a **Repair Order** status changes to `"Ready To Close"`.

---

### 🔧 Backend Implementation

**Trigger Method in `project.py`**
- In the method `set_project_ready_to_close` (found in `erpnext.projects.doctype.project.project`), the following line is added to trigger a custom notification:
  ```python
  project.run_method('notify_ready_to_close')
  ```

**Notification Configuration**
- A new **Notification** document is created, e.g., **"Repair Order Ready For Collection"** with the following configuration:
  - **Document Type**: `Repair Order`
  - **Channel**: `Email` (can be other mediums like Slack, SMS, etc.)
  - **Subject**: Defined email subject
  - **Send Alert On**: `Method` (since the trigger is from a user action or API)
  - **Notification Type**: `"Ready to Close"` (acts as an identifier)
  - **Trigger Method**: `notify_ready_to_close` (same method triggered from `project.py`)
  - **Sender Info**: Auto-fetched from the configured email system (e.g., Gmail)
  - **Recipients**: Add specific email IDs of the intended recipients

**Validation Flow**
- The method `validate_notification` is defined in the controller class.
- It is automatically invoked when `run_validate_notification` is triggered from `notification.py`.

📸 Screenshot for Reference:  
![Screenshot 2025-04-17 233249](https://github.com/user-attachments/assets/df2df125-caf7-4736-87e4-06535af3c6a1)

---

### 💻 Frontend Implementation

**File**: `erpnext/projects/doctype/project/project.js`

To display the **notification sent status** on the frontend:

1. On page load (`onload()` method), the system fetches the count of notifications sent for the `"Ready to Close"` notification type.
2. This is done using:
   ```javascript
   self.set_onload('notification_count', get_all_notification_count(self.doctype, self.name))
   ```
3. This count is then passed to the UI component to display the notification status and medium used (email, etc.).

---

Closes [<link to issue>](https://github.com/ParaLogicTech/automotive/issues/21)