### PR TITLE
[feature]: (#397) account manager filter in sales details

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -387,3 +387,6 @@ execute:frappe.db.set_single_value("Buying Settings", "update_buying_prices_base
 execute:frappe.db.sql("update tabItem set gross_weight_per_unit = tare_weight_per_unit where is_packaging_material = 1")
 erpnext.patches.v14_0.delete_standard_portal_menu_items
 erpnext.patches.v14_0.set_work_order_rejected_qty
+
+# v14.0.0
+erpnext.patches.v14_0.unset_invalid_account_manager_links.execute

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -387,6 +387,4 @@ execute:frappe.db.set_single_value("Buying Settings", "update_buying_prices_base
 execute:frappe.db.sql("update tabItem set gross_weight_per_unit = tare_weight_per_unit where is_packaging_material = 1")
 erpnext.patches.v14_0.delete_standard_portal_menu_items
 erpnext.patches.v14_0.set_work_order_rejected_qty
-
-# v14.0.0
-erpnext.patches.v14_0.unset_invalid_account_manager_links.execute
+erpnext.patches.v14_0.unset_invalid_account_manager_links

--- a/erpnext/patches/v14_0/unset_invalid_account_manager_links.py
+++ b/erpnext/patches/v14_0/unset_invalid_account_manager_links.py
@@ -8,7 +8,7 @@ def execute():
 	
 	# Get all customers that have an account_manager set
 	customers = frappe.get_all("Customer", 
-		filters={"account_manager": ["!=", ""]},
+		filters={"account_manager": ["is", "set"]},
 		fields=["name", "account_manager"]
 	)
 
@@ -19,7 +19,6 @@ def execute():
 	for customer in customers:
 		if customer.account_manager not in valid_sales_persons:
 			frappe.db.set_value("Customer", customer.name, "account_manager", None)
-			frappe.db.commit()
 			
 			# Log the change
 			frappe.logger().info(

--- a/erpnext/patches/v14_0/unset_invalid_account_manager_links.py
+++ b/erpnext/patches/v14_0/unset_invalid_account_manager_links.py
@@ -3,9 +3,10 @@
 
 import frappe
 
+
 def execute():
 	"""Unset any invalid account_manager links in Customer doctype that don't reference a valid Sales Person"""
-	
+
 	# Get all customers that have an account_manager set
 	customers = frappe.get_all("Customer", 
 		filters={"account_manager": ["is", "set"]},
@@ -18,9 +19,9 @@ def execute():
 	# Update customers with invalid account_manager
 	for customer in customers:
 		if customer.account_manager not in valid_sales_persons:
-			frappe.db.set_value("Customer", customer.name, "account_manager", None)
-			
+			frappe.db.set_value("Customer", customer.name, "account_manager", None, update_modified=False)
+
 			# Log the change
-			frappe.logger().info(
+			frappe.logger().warn(
 				f"Unset invalid account_manager '{customer.account_manager}' in Customer '{customer.name}'"
 			)

--- a/erpnext/patches/v14_0/unset_invalid_account_manager_links.py
+++ b/erpnext/patches/v14_0/unset_invalid_account_manager_links.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+def execute():
+	"""Unset any invalid account_manager links in Customer doctype that don't reference a valid Sales Person"""
+	
+	# Get all customers that have an account_manager set
+	customers = frappe.get_all("Customer", 
+		filters={"account_manager": ["!=", ""]},
+		fields=["name", "account_manager"]
+	)
+
+	# Get all valid sales persons
+	valid_sales_persons = set(frappe.get_all("Sales Person", pluck="name"))
+
+	# Update customers with invalid account_manager
+	for customer in customers:
+		if customer.account_manager not in valid_sales_persons:
+			frappe.db.set_value("Customer", customer.name, "account_manager", None)
+			frappe.db.commit()
+			
+			# Log the change
+			frappe.logger().info(
+				f"Unset invalid account_manager '{customer.account_manager}' in Customer '{customer.name}'"
+			)

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -188,7 +188,7 @@
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Account Manager",
-   "options": "User"
+   "options": "Sales Person"
   },
   {
    "fieldname": "customer_group",

--- a/erpnext/selling/report/sales_details/sales_details.js
+++ b/erpnext/selling/report/sales_details/sales_details.js
@@ -131,6 +131,12 @@ frappe.query_reports["Sales Details"] = {
 			options: "Sales Person"
 		},
 		{
+			fieldname: "account_manager",
+			label: __("Account Manager"),
+			fieldtype: "Link",
+			options: "Sales Person"
+		},
+		{
 			"fieldname":"cost_center",
 			"label": __("Cost Center"),
 			"fieldtype": "MultiSelectList",

--- a/erpnext/selling/report/sales_details/sales_details.py
+++ b/erpnext/selling/report/sales_details/sales_details.py
@@ -221,7 +221,9 @@ class SalesPurchaseDetailsReport(object):
 			conditions.append("s.customer = %(customer)s")
 
 		if self.filters.get("account_manager"):
-			conditions.append("cus.account_manager = %(account_manager)s")
+			lft, rgt = frappe.db.get_value("Sales Person", self.filters.account_manager, ["lft", "rgt"])
+			conditions.append("""cus.account_manager in (select name from `tabSales Person`
+				where lft >= {0} and rgt <= {1})""".format(lft, rgt))
 
 		if self.filters.get("customer_group"):
 			lft, rgt = frappe.db.get_value("Customer Group", self.filters.customer_group, ["lft", "rgt"])
@@ -823,7 +825,7 @@ class SalesPurchaseDetailsReport(object):
 				"label": _("Account Manager"),
 				"fieldname": "account_manager",
 				"fieldtype": "Link",
-				"options": "User",
+				"options": "Sales Person",
 				"width": 120
 			})
 

--- a/erpnext/selling/report/sales_details/sales_details.py
+++ b/erpnext/selling/report/sales_details/sales_details.py
@@ -353,6 +353,9 @@ class SalesPurchaseDetailsReport(object):
 				d['reference_type'] = self.filters.doctype
 				d['reference'] = d.get("parent")
 
+			if d.get("account_manager"):
+				self.filters.has_account_manager = True
+
 			# Add tax fields
 			for f, tax in zip(self.tax_amount_fields, self.tax_columns):
 				tax_amount = self.itemised_tax.get(d.name, {}).get(tax, {}).get("tax_amount", 0.0)
@@ -789,13 +792,6 @@ class SalesPurchaseDetailsReport(object):
 					},
 				]
 
-		# Check if any entry has an account_manager value
-		has_account_manager = False
-		for entry in self.entries:
-			if entry.get("account_manager"):
-				has_account_manager = True
-				break
-
 		columns += [
 			{
 				"label": _("Package"),
@@ -817,19 +813,13 @@ class SalesPurchaseDetailsReport(object):
 				"options": "Territory",
 				"width": 100
 			},
-		]
-
-		# Add Account Manager column only if there's a value in the dataset
-		if has_account_manager:
-			columns.append({
+			{
 				"label": _("Account Manager"),
 				"fieldname": "account_manager",
 				"fieldtype": "Link",
 				"options": "Sales Person",
-				"width": 120
-			})
-
-		columns += [
+				"width": 110
+			},
 			{
 				"label": _("Cost Center"),
 				"fieldname": "cost_center",
@@ -889,6 +879,9 @@ class SalesPurchaseDetailsReport(object):
 
 		if not self.filters.show_packing_slip:
 			columns = [c for c in columns if c.get('fieldname') != 'packing_slip']
+
+		if not self.filters.has_account_manager:
+			columns = [c for c in columns if c.get('fieldname') != 'account_manager']
 
 		if self.filters.totals_only:
 			if "item_code" not in self.group_by:

--- a/erpnext/selling/report/sales_details/sales_details.py
+++ b/erpnext/selling/report/sales_details/sales_details.py
@@ -169,7 +169,7 @@ class SalesPurchaseDetailsReport(object):
 		# Party
 		if self.filters.party_type == "Customer":
 			joins.append("inner join `tabCustomer` cus on cus.name = s.customer")
-			select_fields += ["cus.customer_group as party_group", "'Customer Group' as party_group_dt"]
+			select_fields += ["cus.customer_group as party_group", "'Customer Group' as party_group_dt", "cus.account_manager"]
 		elif self.filters.party_type == "Supplier":
 			joins.append("inner join `tabSupplier` sup on sup.name = s.supplier")
 			select_fields += ["sup.supplier_group as party_group", "'Supplier Group' as party_group_dt"]
@@ -219,6 +219,9 @@ class SalesPurchaseDetailsReport(object):
 
 		if self.filters.get("customer"):
 			conditions.append("s.customer = %(customer)s")
+
+		if self.filters.get("account_manager"):
+			conditions.append("cus.account_manager = %(account_manager)s")
 
 		if self.filters.get("customer_group"):
 			lft, rgt = frappe.db.get_value("Customer Group", self.filters.customer_group, ["lft", "rgt"])
@@ -784,6 +787,13 @@ class SalesPurchaseDetailsReport(object):
 					},
 				]
 
+		# Check if any entry has an account_manager value
+		has_account_manager = False
+		for entry in self.entries:
+			if entry.get("account_manager"):
+				has_account_manager = True
+				break
+
 		columns += [
 			{
 				"label": _("Package"),
@@ -805,6 +815,19 @@ class SalesPurchaseDetailsReport(object):
 				"options": "Territory",
 				"width": 100
 			},
+		]
+
+		# Add Account Manager column only if there's a value in the dataset
+		if has_account_manager:
+			columns.append({
+				"label": _("Account Manager"),
+				"fieldname": "account_manager",
+				"fieldtype": "Link",
+				"options": "User",
+				"width": 120
+			})
+
+		columns += [
 			{
 				"label": _("Cost Center"),
 				"fieldname": "cost_center",


### PR DESCRIPTION
**🛠️ Pull Request Description**


**Feature**: Add account manager filter in sales details.

**Implementation Details**
 1. Changed account manager to get options as Sales Person instead of users
 2. Added a filter (Account Manager) in the sales details report.
 3. Added a additional column (Account Manager) which gets displayed if any entry has an account_manager value or else it's hidden.
 
 Closes [](https://github.com/ParaLogicTech/erpnext/issues/397)