### PR TITLE
[feature]: (#15) remove group by filters and add from date and to date filters

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -530,8 +530,28 @@ $.extend(erpnext.utils, {
 			const company = cur_frm?.doc?.company;
 			const customer = cur_frm?.doc?.customer;
             if (doc?.item_code && customer && company) {
-                const link = `/app/query-report/Sales Details?company=${encodeURIComponent(company)}&customer=${encodeURIComponent(customer)}&item_code=${encodeURIComponent(doc.item_code)}`;
-                return `<a href="${link}" target="_blank">${formatted_value}</a>`;
+				const today = new Date();
+				const fromDate = new Date();
+				fromDate.setFullYear(today.getFullYear() - 2);
+
+				const formatDate = (date) => date.toISOString().split('T')[0];
+
+				const from_date = formatDate(fromDate);
+				const to_date = formatDate(today);
+                const filters = {
+					company,
+					customer,
+					item_code: doc.item_code,
+					doctype: "Sales Invoice",
+					qty_field: "Stock Qty",
+					from_date,
+					to_date,
+					group_by_2: "",
+					group_by_3: "",
+					group_same_items: 0
+				};
+
+				return `<a href="#" onclick='frappe.set_route("query-report", "Sales Details", ${JSON.stringify(filters)})' style="text-decoration: underline;">${formatted_value}</a>`;
             }
 
             return formatted_value;

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -530,28 +530,31 @@ $.extend(erpnext.utils, {
 			const company = cur_frm?.doc?.company;
 			const customer = cur_frm?.doc?.customer;
 			if (doc?.item_code && customer && company) {
-				const today = new Date();
-				const fromDate = new Date();
-				fromDate.setFullYear(today.getFullYear() - 2);
+				const today = frappe.datetime.get_today();
+				const from_date = moment(today).subtract(2, 'years').format('YYYY-MM-DD');
+				frappe.msgprint(moment(today).subtract(2, 'years'));
 
-				const formatDate = (date) => date.toISOString().split('T')[0];
-
-				const from_date = formatDate(fromDate);
-				const to_date = formatDate(today);
-				const filters = {
-					company,
-					customer,
+				const params = {
+					company: company,
+					customer: customer,
 					item_code: doc.item_code,
-					doctype: "Sales Invoice",
-					qty_field: "Stock Qty",
-					from_date,
-					to_date,
-					group_by_2: "",
-					group_by_3: "",
-					group_same_items: 0
+					from_date: from_date,
+					to_date: today,
+					doctype: 'Sales Invoice',
+					qty_field: 'Stock Qty',
+					group_by_1: '',
+					group_by_2: '',
+					group_by_3: '',
+					group_same_items: 0,
 				};
 
-				return `<a href="#" onclick='frappe.set_route("query-report", "Sales Details", ${JSON.stringify(filters)})' style="text-decoration: underline;">${formatted_value}</a>`;
+				const query_string = Object.entries(params)
+					.map(([key, val]) => `${key}=${encodeURIComponent(val)}`)
+					.join('&');
+
+				const link = `/app/query-report/Sales Details?${query_string}`;
+
+				return `<a href="${link}" target="_blank">${formatted_value}</a>`;
 			}
 
             return formatted_value;

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -532,7 +532,6 @@ $.extend(erpnext.utils, {
 			if (doc?.item_code && customer && company) {
 				const today = frappe.datetime.get_today();
 				const from_date = moment(today).subtract(2, 'years').format('YYYY-MM-DD');
-				frappe.msgprint(moment(today).subtract(2, 'years'));
 
 				const params = {
 					company: company,

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -516,16 +516,16 @@ $.extend(erpnext.utils, {
 		}
 	},
 
-    setup_last_billed_rate_formatter(doctype, fieldname) {
-        let df = frappe.meta.get_docfield(doctype, fieldname);
-        if (df) {
-            erpnext.utils.set_last_billed_rate_link_formatter(df);
-        }
-    },
+	setup_last_billed_rate_formatter(doctype, fieldname) {
+		let df = frappe.meta.get_docfield(doctype, fieldname);
+		if (df) {
+			erpnext.utils.set_last_billed_rate_link_formatter(df);
+		}
+	},
 
-    set_last_billed_rate_link_formatter(df) {
-        df.formatter = (value, df, options, doc) => {
-            let formatted_value = frappe.format(value, df, options, doc, true);
+	set_last_billed_rate_link_formatter(df) {
+		df.formatter = (value, df, options, doc) => {
+			let formatted_value = frappe.format(value, df, options, doc, true);
 
 			const company = cur_frm?.doc?.company;
 			const customer = cur_frm?.doc?.customer;
@@ -557,9 +557,9 @@ $.extend(erpnext.utils, {
 				return `<a href="${link}" target="_blank">${formatted_value}</a>`;
 			}
 
-            return formatted_value;
-        };
-    },
+			return formatted_value;
+		};
+	},
 });
 
 erpnext.utils.select_alternate_items = function(opts) {

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -529,7 +529,7 @@ $.extend(erpnext.utils, {
 
 			const company = cur_frm?.doc?.company;
 			const customer = cur_frm?.doc?.customer;
-            if (doc?.item_code && customer && company) {
+			if (doc?.item_code && customer && company) {
 				const today = new Date();
 				const fromDate = new Date();
 				fromDate.setFullYear(today.getFullYear() - 2);
@@ -538,7 +538,7 @@ $.extend(erpnext.utils, {
 
 				const from_date = formatDate(fromDate);
 				const to_date = formatDate(today);
-                const filters = {
+				const filters = {
 					company,
 					customer,
 					item_code: doc.item_code,
@@ -552,7 +552,7 @@ $.extend(erpnext.utils, {
 				};
 
 				return `<a href="#" onclick='frappe.set_route("query-report", "Sales Details", ${JSON.stringify(filters)})' style="text-decoration: underline;">${formatted_value}</a>`;
-            }
+			}
 
             return formatted_value;
         };


### PR DESCRIPTION
Closes https://github.com/ParaLogicTech/moghul_custom/issues/15

**Description:**
---
This PR updates the report navigation to use frappe.set_route() instead of raw URLs. It solves the following issues:

- Prevents default group_by filters from being automatically applied, which can happen with saved filter states or raw URLs.

- Sets the from_date and to_date dynamically to the last two years and the current date, ensuring accurate and consistent date range filtering.