### PR TITLE
[feature]: (#439) Add insurance excess invoice customer validation

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -816,7 +816,8 @@ class Project(StatusUpdaterERP):
 
 	def validate_for_transaction(self, doc):
 		if doc.doctype in ("Sales Invoice", "Service Warranty"):
-			self.check_is_ready_to_close()
+			if not self.is_insurance_excess_invoice_for_customer(doc):
+				self.check_is_ready_to_close()
 		if doc.doctype == "Sales Invoice":
 			self.check_undelivered_sales_orders()
 		if doc.doctype == "Payment Entry":
@@ -876,6 +877,24 @@ class Project(StatusUpdaterERP):
 			frappe.throw(_("Customer in Payment Entry does not match with {0}. Customer must be {1}").format(
 				frappe.get_desk_link("Project", self.name), comma_or(allowed_customers)
 			))
+
+	def is_insurance_excess_invoice_for_customer(self, doc):
+		if doc.doctype != "Sales Invoice":
+			return False
+
+		insurance_excess_item = frappe.get_cached_value("Projects Settings", None, "insurance_excess_item")
+		if not insurance_excess_item:
+			return False
+
+		billed_to = doc.bill_to or doc.customer
+		if billed_to != self.customer:
+			return False
+
+		for item in doc.items:
+			if item.item_code == insurance_excess_item:
+				return True
+
+		return False
 
 	def check_po_no_is_set(self, doc):
 		if self.po_no or doc.is_pos:

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -815,13 +815,16 @@ class Project(StatusUpdaterERP):
 			}, None)
 
 	def validate_for_transaction(self, doc):
-		if doc.doctype in ("Sales Invoice", "Service Warranty"):
+		if doc.doctype == "Sales Invoice":
 			if not self.is_insurance_excess_invoice_for_customer(doc):
 				self.check_is_ready_to_close()
-		if doc.doctype == "Sales Invoice":
-			self.check_undelivered_sales_orders()
+				self.check_undelivered_sales_orders()
+
 		if doc.doctype == "Payment Entry":
 			self.validate_payment_entry_customer(doc)
+
+		if doc.doctype == "Service Warranty":
+			self.check_is_ready_to_close()
 
 	def check_is_ready_to_close(self):
 		if not frappe.get_cached_value("Projects Settings", None, "validate_ready_to_close"):
@@ -890,11 +893,7 @@ class Project(StatusUpdaterERP):
 		if billed_to != self.customer:
 			return False
 
-		for item in doc.items:
-			if item.item_code == insurance_excess_item:
-				return True
-
-		return False
+		return doc.items and all(d.item_code == insurance_excess_item for d in doc.items)
 
 	def check_po_no_is_set(self, doc):
 		if self.po_no or doc.is_pos:


### PR DESCRIPTION
## Description

Add validation to check if a Sales Invoice contains at least one insurance excess item and is billed to the correct customer.

## Changes
- Verify document is a Sales Invoice
- Fetch insurance excess item from Project Settings
- Check invoice billed to the expected customer (`self.customer`)
- Confirm presence of at least one insurance excess item in invoice items

## Purpose
This validation ensures insurance excess invoices are correctly associated with the intended customer, improving data accuracy and process reliability.


Closes https://github.com/ParaLogicTech/erpnext/issues/439