### PR TITLE
[feature]: (#56) added break hours in company, employee checkin sheet

### DIFF
--- a/erpnext/hr/report/employee_checkin_sheet/employee_checkin_sheet.py
+++ b/erpnext/hr/report/employee_checkin_sheet/employee_checkin_sheet.py
@@ -102,11 +102,9 @@ def execute(filters=None):
 							row['attendance_request'] = attendance_details.attendance_request
 							row['remarks'] = attendance_details.remarks or attendance_details.leave_type or attendance_details.attendance_request_reason or row.remarks
 
-							if attendance_details.working_hours:
-								row['working_hours'] = attendance_details.working_hours
-								row['break_hours'] = 0
-							if attendance_details.break_hours:
-								row['break_hours'] = attendance_details.break_hours
+							row['working_hours'] = attendance_details.working_hours
+							row['break_hours'] = attendance_details.break_hours
+							row['available_hours'] = attendance_details.available_hours
 
 						row['attendance_marked'] = 1 if attendance_details else 0
 
@@ -131,18 +129,20 @@ def execute(filters=None):
 								row['attendance_abbr'] = get_attendance_status_abbr(attendance_status, late_entry, early_exit)
 								row['late_entry'] = late_entry
 								row['early_exit'] = early_exit
-								if working_hours:
-									row['working_hours'] = working_hours
-									row['break_hours'] = flt(frappe.get_cached_value("Shift Type", shift_type, "break_hours"))
+								row['working_hours'] = working_hours
+
+								row['break_hours'] = flt(frappe.get_cached_value("Shift Type", shift_type, "break_hours"))
+								if flt(row.get("break_hours")) >= flt(row.get("working_hours")):
+									row['break_hours'] = 0
+								row['available_hours'] = flt(row.get('working_hours')) - flt(row.get('break_hours'))
 
 							elif not is_holiday and shift_ended(shift_type, attendance_date=current_date):
 								row['attendance_status'] = "Absent"
 
-						if row.get("break_hours") and flt(row.get("break_hours")) >= flt(row.get("working_hours")):
-							row['break_hours'] = 0
-
-						if flt(row.get('working_hours')):
-							row['available_hours'] = flt(row.get('working_hours')) - flt(row.get('break_hours'))
+						if not row.get("working_hours") and not row.get("break_hours") and not row.get("available_hours"):
+							row["working_hours"] = None
+							row["break_hours"] = None
+							row["available_hours"] = None
 
 						row['late_entry_hours'] = get_late_entry_hours(row, checkins)
 						row['early_exit_hours'] = get_early_exit_hours(row, checkins)

--- a/erpnext/hr/report/employee_checkin_sheet/employee_checkin_sheet.py
+++ b/erpnext/hr/report/employee_checkin_sheet/employee_checkin_sheet.py
@@ -32,8 +32,6 @@ def execute(filters=None):
 	data = []
 
 	checkin_column_count = 1
-	company_doc = frappe.get_cached_doc("Company", filters.company)
-	default_break_hours = flt(company_doc.get("break_hours", 0.0))
 	current_date = filters.from_date
 	while current_date <= filters.to_date:
 		day = get_weekday(current_date)
@@ -48,8 +46,6 @@ def execute(filters=None):
 					'department': employee_details.department,
 					'designation': employee_details.designation,
 					'disable_party_name_formatter': 1,
-					'break_hours': None,
-					'available_hours': None,
 				})
 
 				is_holiday = is_date_holiday(current_date, holiday_map, employee_details, filters.default_holiday_list)
@@ -108,6 +104,9 @@ def execute(filters=None):
 
 							if attendance_details.working_hours:
 								row['working_hours'] = attendance_details.working_hours
+								row['break_hours'] = 0
+							if attendance_details.break_hours:
+								row['break_hours'] = attendance_details.break_hours
 
 						row['attendance_marked'] = 1 if attendance_details else 0
 
@@ -134,11 +133,15 @@ def execute(filters=None):
 								row['early_exit'] = early_exit
 								if working_hours:
 									row['working_hours'] = working_hours
+									row['break_hours'] = flt(frappe.get_cached_value("Shift Type", shift_type, "break_hours"))
+
 							elif not is_holiday and shift_ended(shift_type, attendance_date=current_date):
 								row['attendance_status'] = "Absent"
 
-						if flt(row.get('working_hours')) > 0:
-							row['break_hours'] = default_break_hours
+						if row.get("break_hours") and flt(row.get("break_hours")) >= flt(row.get("working_hours")):
+							row['break_hours'] = 0
+
+						if flt(row.get('working_hours')):
 							row['available_hours'] = flt(row.get('working_hours')) - flt(row.get('break_hours'))
 
 						row['late_entry_hours'] = get_late_entry_hours(row, checkins)
@@ -253,12 +256,10 @@ def calculate_totals(employee, data, filters):
 					totals['total_lwp'] += leave_count
 
 		# total hours
-		if d.break_hours:
-			totals['total_break_hours'] += flt(d.break_hours)
-		if d.available_hours:
-			totals['total_available_hours'] += flt(d.available_hours)
-
 		totals['total_working_hours'] += flt(d.working_hours)
+		totals['total_break_hours'] += flt(d.break_hours)
+		totals['total_available_hours'] += flt(d.available_hours)
+
 		totals['total_late_entry_hours'] += flt(d.late_entry_hours)
 		totals['total_early_exit_hours'] += flt(d.early_exit_hours)
 
@@ -336,7 +337,8 @@ def get_attendance_map(filters):
 
 	attendance = frappe.db.sql("""
 		select att.name, att.employee, att.attendance_date, att.shift,
-			att.status, att.late_entry, att.early_exit, att.working_hours,
+			att.status, att.late_entry, att.early_exit,
+			att.working_hours, att.break_hours, att.available_hours,
 			att.leave_application, att.attendance_request,
 			att.remarks, att.leave_type, arq.reason as attendance_request_reason
 		from `tabAttendance` att
@@ -404,8 +406,8 @@ def get_columns(filters, checkin_column_count, totals):
 		{"fieldname": "attendance_status", "label": _("Status"), "fieldtype": "Data", "width": 75},
 		{"fieldname": "remarks", "label": _("Remarks"), "fieldtype": "Data", "width": 100},
 		{"fieldname": "working_hours", "label": _("W. Hours"), "fieldtype": "Float", "width": 65, "precision": 1},
-		{"fieldname": "break_hours", "label": _("Break. Hours"), "fieldtype": "Float", "width": 65, "precision": 1},
-		{"fieldname": "available_hours", "label": _("A. Hours"), "fieldtype": "Float", "width": 65, "precision": 1},
+		{"fieldname": "break_hours", "label": _("Brk. Hours"), "fieldtype": "Float", "width": 72, "precision": 1},
+		{"fieldname": "available_hours", "label": _("Avl. Hours"), "fieldtype": "Float", "width": 70, "precision": 1},
 		{"fieldname": "late_entry_hours", "label": _("Late Hours"), "fieldtype": "Float", "width": 75, "precision": 1},
 		{"fieldname": "early_exit_hours", "label": _("Early Exit Hours"), "fieldtype": "Float", "width": 77, "precision": 1},
 		{"fieldname": "leave_application", "label": _("Leave Application"), "fieldtype": "Link", "options": "Leave Application", "width": 130},

--- a/erpnext/hr/report/employee_checkin_sheet/employee_checkin_sheet.py
+++ b/erpnext/hr/report/employee_checkin_sheet/employee_checkin_sheet.py
@@ -32,7 +32,8 @@ def execute(filters=None):
 	data = []
 
 	checkin_column_count = 1
-
+	company_doc = frappe.get_cached_doc("Company", filters.company)
+	default_break_hours = flt(company_doc.get("break_hours", 0.0))
 	current_date = filters.from_date
 	while current_date <= filters.to_date:
 		day = get_weekday(current_date)
@@ -47,6 +48,8 @@ def execute(filters=None):
 					'department': employee_details.department,
 					'designation': employee_details.designation,
 					'disable_party_name_formatter': 1,
+					'break_hours': None,
+					'available_hours': None,
 				})
 
 				is_holiday = is_date_holiday(current_date, holiday_map, employee_details, filters.default_holiday_list)
@@ -134,6 +137,10 @@ def execute(filters=None):
 							elif not is_holiday and shift_ended(shift_type, attendance_date=current_date):
 								row['attendance_status'] = "Absent"
 
+						if flt(row.get('working_hours')) > 0:
+							row['break_hours'] = default_break_hours
+							row['available_hours'] = flt(row.get('working_hours')) - flt(row.get('break_hours'))
+
 						row['late_entry_hours'] = get_late_entry_hours(row, checkins)
 						row['early_exit_hours'] = get_early_exit_hours(row, checkins)
 
@@ -203,6 +210,8 @@ def calculate_totals(employee, data, filters):
 		"total_working_hours": 0,
 		"total_late_entry_hours": 0,
 		"total_early_exit_hours": 0,
+		"total_break_hours": 0,
+		"total_available_hours": 0,
 	})
 
 	for d in data:
@@ -244,6 +253,11 @@ def calculate_totals(employee, data, filters):
 					totals['total_lwp'] += leave_count
 
 		# total hours
+		if d.break_hours:
+			totals['total_break_hours'] += flt(d.break_hours)
+		if d.available_hours:
+			totals['total_available_hours'] += flt(d.available_hours)
+
 		totals['total_working_hours'] += flt(d.working_hours)
 		totals['total_late_entry_hours'] += flt(d.late_entry_hours)
 		totals['total_early_exit_hours'] += flt(d.early_exit_hours)
@@ -272,6 +286,8 @@ def calculate_totals(employee, data, filters):
 	totals['total_working_hours'] = flt(totals['total_working_hours'], 1)
 	totals['total_late_entry_hours'] = flt(totals['total_late_entry_hours'], 1)
 	totals['total_early_exit_hours'] = flt(totals['total_early_exit_hours'], 1)
+	totals['total_break_hours'] = flt(totals['total_break_hours'], 1)
+	totals['total_available_hours'] = flt(totals['total_available_hours'], 1)
 
 	return totals
 
@@ -388,6 +404,8 @@ def get_columns(filters, checkin_column_count, totals):
 		{"fieldname": "attendance_status", "label": _("Status"), "fieldtype": "Data", "width": 75},
 		{"fieldname": "remarks", "label": _("Remarks"), "fieldtype": "Data", "width": 100},
 		{"fieldname": "working_hours", "label": _("W. Hours"), "fieldtype": "Float", "width": 65, "precision": 1},
+		{"fieldname": "break_hours", "label": _("Break. Hours"), "fieldtype": "Float", "width": 65, "precision": 1},
+		{"fieldname": "available_hours", "label": _("A. Hours"), "fieldtype": "Float", "width": 65, "precision": 1},
 		{"fieldname": "late_entry_hours", "label": _("Late Hours"), "fieldtype": "Float", "width": 75, "precision": 1},
 		{"fieldname": "early_exit_hours", "label": _("Early Exit Hours"), "fieldtype": "Float", "width": 77, "precision": 1},
 		{"fieldname": "leave_application", "label": _("Leave Application"), "fieldtype": "Link", "options": "Leave Application", "width": 130},
@@ -463,6 +481,20 @@ def get_totals_summary(totals):
 			"label": _("Total Working Hours"),
 			"value": totals.total_working_hours,
 			"indicator": "blue" if totals.total_working_hours > 0 else "grey",
+			"datatype": "Float",
+			"precision": 1,
+		},
+		{
+			"label": _("Total Break Hours"),
+			"value": totals.total_break_hours,
+			"indicator": "blue" if totals.total_break_hours > 0 else "grey",
+			"datatype": "Float",
+			"precision": 1,
+		},
+		{
+			"label": _("Total Available Hours"),
+			"value": totals.total_available_hours,
+			"indicator": "blue" if totals.total_available_hours > 0 else "grey",
 			"datatype": "Float",
 			"precision": 1,
 		},

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -66,6 +66,7 @@
   "default_leave_policy",
   "column_break_24",
   "standard_working_hours",
+  "break_hours",
   "accounts_settings",
   "tax_settings_section",
   "tax_id",
@@ -1033,6 +1034,12 @@
    "label": "Stock Delivered But Not Billed",
    "no_copy": 1,
    "options": "Account"
+  },
+  {
+   "fieldname": "break_hours",
+   "fieldtype": "Float",
+   "label": "Break Hours",
+   "non_negative": 1
   }
  ],
  "icon": "fa fa-building",
@@ -1040,7 +1047,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2025-03-27 20:38:19.466124",
+ "modified": "2025-06-10 10:45:15.834587",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -62,11 +62,10 @@
   "default_buying_terms",
   "hr_settings_section",
   "default_holiday_list",
-  "column_break_36",
   "default_leave_policy",
   "column_break_24",
   "standard_working_hours",
-  "break_hours",
+  "standard_break_hours",
   "accounts_settings",
   "tax_settings_section",
   "tax_id",
@@ -904,10 +903,6 @@
    "options": "\nFiler\nNon Filer\nExempt"
   },
   {
-   "fieldname": "column_break_36",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "default_leave_policy",
    "fieldtype": "Link",
    "label": "Default Leave Policy",
@@ -1036,9 +1031,9 @@
    "options": "Account"
   },
   {
-   "fieldname": "break_hours",
+   "fieldname": "standard_break_hours",
    "fieldtype": "Float",
-   "label": "Break Hours",
+   "label": "Standard Break Hours",
    "non_negative": 1
   }
  ],
@@ -1047,7 +1042,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2025-06-10 10:45:15.834587",
+ "modified": "2025-06-12 12:35:05.388441",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",


### PR DESCRIPTION
# Add Break/Lunch Hours Consideration in Available Hours Calculation

## Description

This PR implements the **Available Hours** feature, which accounts for **break/lunch hours** in the calculation of available hours for employee attendance. The changes ensure that break hours, configured at the **Company** level, are deducted from working hours to compute available hours accurately.

---

## Changes

### 🏷 Terminology Implementation
- **Working Hours**: Defined as total time spent at the location (attendance hours).
- **Break Hours**: Introduced as a configurable field in Company HR settings.
- **Available Hours**: Computed as `Working Hours - Break Hours`.

### 🧠 Attendance Data Logic
- Break hours are deducted **only** when working hours are present.
- For attendance records with **no working hours**, no break hours are applied.

### 📊 Report Updates
- Modified the **Employee Checkin Sheet** to include a new columns:
  - `Break Hours` and  `Available Hours` alongside `Working Hours`.

### ✅ Consistency
- All calculations align with configured break hours at the Company level.

---

## Testing

- ✅ Verified break hours are correctly deducted **only when working hours are present**.
- ✅ Confirmed the **Employee Checkin Sheet** accurately displays the new `Available Hours` column.
---

## Screenshots

![Break Hours Configuration](https://github.com/user-attachments/assets/4cfc9bb0-05f4-45c8-bbb5-1edbd8f2c67d)

![Employee Checkin Sheet Update](https://github.com/user-attachments/assets/bb67f582-973b-43c3-a268-24728c8384fe)

Closes https://github.com/ParaLogicTech/automotive/issues/56