### PR TITLE
[feature] : (#459) added update vehicle details for submitted invoices

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -65,6 +65,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends e
 
 		// Update Buttons
 		this.add_update_customer_name_button();
+		this.add_update_vehicle_details_button();
 
 		// Pricing Buttons
 		if (this.frm.doc.docstatus == 0) {

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -65,7 +65,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends e
 
 		// Update Buttons
 		this.add_update_customer_name_button();
-		this.add_update_vehicle_details_button();
+		this.add_update_applies_to_details_button();
 
 		// Pricing Buttons
 		if (this.frm.doc.docstatus == 0) {

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -860,8 +860,7 @@ def update_customer_name_from_master(doctype, name):
 
 
 @frappe.whitelist()
-def update_vehicle_details_from_master(doctype, name):
-	from automotive.controllers.vehicle_transaction_controller import get_vehicle_details
+def update_applies_to_details(doctype, name):
 
 	if doctype not in ("Quotation", "Sales Order", "Delivery Note", "Sales Invoice"):
 		frappe.throw(_("DocType {0} not allowed").format(doctype))
@@ -871,18 +870,12 @@ def update_vehicle_details_from_master(doctype, name):
 	if doc.docstatus != 1:
 		frappe.throw(_("{0} {1} is not submitted").format(doctype, name))
 
-	if not doc.get("applies_to_vehicle"):
-		frappe.throw(_("No vehicle found for {0} {1}").format(doctype, name))
 
 	doc.check_permission("submit")
 	doc._doc_before_save = frappe.get_doc(doc.as_dict())
 
-	if doc.get("applies_to_vehicle"):
-		vehicle_details = get_vehicle_details({"vehicle": doc.applies_to_vehicle})
-		if vehicle_details:
-			for field, value in vehicle_details.items():
-				if doc.meta.has_field(field):
-					doc.db_set(field, value)
+	doc.set_missing_applies_to_details()
+	doc.db_update()
 
 	doc.notify_update()
 	doc.save_version()

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -860,8 +860,7 @@ def update_customer_name_from_master(doctype, name):
 
 
 @frappe.whitelist()
-def update_applies_to_details(doctype, name):
-
+def update_applies_to_details_from_master(doctype, name):
 	if doctype not in ("Quotation", "Sales Order", "Delivery Note", "Sales Invoice"):
 		frappe.throw(_("DocType {0} not allowed").format(doctype))
 
@@ -869,7 +868,6 @@ def update_applies_to_details(doctype, name):
 
 	if doc.docstatus != 1:
 		frappe.throw(_("{0} {1} is not submitted").format(doctype, name))
-
 
 	doc.check_permission("submit")
 	doc._doc_before_save = frappe.get_doc(doc.as_dict())

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -857,3 +857,32 @@ def update_customer_name_from_master(doctype, name):
 
 	doc.notify_update()
 	doc.save_version()
+
+
+@frappe.whitelist()
+def update_vehicle_details_from_master(doctype, name):
+	from automotive.controllers.vehicle_transaction_controller import get_vehicle_details
+
+	if doctype not in ("Quotation", "Sales Order", "Delivery Note", "Sales Invoice"):
+		frappe.throw(_("DocType {0} not allowed").format(doctype))
+
+	doc = frappe.get_doc(doctype, name)
+
+	if doc.docstatus != 1:
+		frappe.throw(_("{0} {1} is not submitted").format(doctype, name))
+
+	if not doc.get("applies_to_vehicle"):
+		frappe.throw(_("No vehicle found for {0} {1}").format(doctype, name))
+
+	doc.check_permission("submit")
+	doc._doc_before_save = frappe.get_doc(doc.as_dict())
+
+	if doc.get("applies_to_vehicle"):
+		vehicle_details = get_vehicle_details({"vehicle": doc.applies_to_vehicle})
+		if vehicle_details:
+			for field, value in vehicle_details.items():
+				if doc.meta.has_field(field):
+					doc.db_set(field, value)
+
+	doc.notify_update()
+	doc.save_version()

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -684,4 +684,33 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 			}
 		})
 	}
+
+	add_update_vehicle_details_button() {
+		let me = this;
+		if (me.frm.doc.docstatus == 1 && me.frm.has_perm("submit")) {
+			me.frm.add_custom_button(__("Set Updated Vehicle Details"), function () {
+				return me.update_vehicle_details_from_master();
+			}, __("Update"));
+		}
+	}
+
+	update_vehicle_details_from_master() {
+		let me = this;
+		if (me.frm.doc.__islocal) {
+			return;
+		}
+
+		return frappe.call({
+			method: "erpnext.controllers.selling_controller.update_vehicle_details_from_master",
+			args: {
+				doctype: me.frm.doc.doctype,
+				name: me.frm.doc.name,
+			},
+			callback: function (r) {
+				if (!r.exc) {
+					me.frm.reload_doc();
+				}
+			}
+		})
+	}
 };

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -685,23 +685,27 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 		})
 	}
 
-	add_update_vehicle_details_button() {
+	add_update_applies_to_details_button() {
 		let me = this;
-		if (me.frm.doc.docstatus == 1 && me.frm.has_perm("submit")) {
-			me.frm.add_custom_button(__("Set Updated Vehicle Details"), function () {
-				return me.update_vehicle_details_from_master();
+		if (
+			me.frm.doc.docstatus == 1 &&
+			me.frm.has_perm("submit") &&
+			me.frm.doc.applies_to_serial_no
+		) {
+			me.frm.add_custom_button(__("Set Updated Applies to Details"), function () {
+				return me.set_updated_applies_to_details();
 			}, __("Update"));
 		}
 	}
 
-	update_vehicle_details_from_master() {
+	set_updated_applies_to_details() {
 		let me = this;
 		if (me.frm.doc.__islocal) {
 			return;
 		}
 
 		return frappe.call({
-			method: "erpnext.controllers.selling_controller.update_vehicle_details_from_master",
+			method: "erpnext.controllers.selling_controller.update_applies_to_details",
 			args: {
 				doctype: me.frm.doc.doctype,
 				name: me.frm.doc.name,

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -688,24 +688,24 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 	add_update_applies_to_details_button() {
 		let me = this;
 		if (
-			me.frm.doc.docstatus == 1 &&
-			me.frm.has_perm("submit") &&
-			me.frm.doc.applies_to_serial_no
+			me.frm.doc.docstatus == 1
+			&& me.frm.has_perm("submit")
+			&& me.frm.doc.applies_to_serial_no
 		) {
-			me.frm.add_custom_button(__("Set Updated Applies to Details"), function () {
-				return me.set_updated_applies_to_details();
+			me.frm.add_custom_button(__("Set Updated Applies To Details"), function () {
+				return me.update_applies_to_details_from_master();
 			}, __("Update"));
 		}
 	}
 
-	set_updated_applies_to_details() {
+	update_applies_to_details_from_master() {
 		let me = this;
 		if (me.frm.doc.__islocal) {
 			return;
 		}
 
 		return frappe.call({
-			method: "erpnext.controllers.selling_controller.update_applies_to_details",
+			method: "erpnext.controllers.selling_controller.update_applies_to_details_from_master",
 			args: {
 				doctype: me.frm.doc.doctype,
 				name: me.frm.doc.name,


### PR DESCRIPTION
**Description**:

This PR introduces a new "Set Updated Vehicle Details" button in the Sales Invoice form, similar to the existing "Set Updated Customer Name" functionality.

**Purpose**:
To allow users to refresh and update vehicle-related fields in a submitted invoice based on the latest data from the vehicle master.
Avoids the need to cancel and amend the invoice just to sync vehicle details.

**Implementation**:
Added a button set_updated_vehicle_details for submitted invoices.
On click, it invokes update_vehicle_details_from_master to fetch the latest vehicle data and update relevant fields.
Ensures consistency of vehicle details across documents even after master data changes.

**Notes**:
Similar logic and pattern followed as in update_customer_name_from_master.
Only applicable to submitted invoices to maintain data integrity and reduce manual effort.

Closes https://github.com/ParaLogicTech/erpnext/issues/459