### PR TITLE
[fix] Pricing Rule: (#468) consider bill_to fix

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -311,6 +311,8 @@ def get_pricing_rule_for_item(args, price_list_rate=0, doc=None, for_validate=Fa
 
 
 def update_args_for_pricing_rule(args):
+	if args.get("bill_to"):
+		args.customer = args.bill_to
 	if not args.item_group:
 		args.item_group = frappe.get_cached_value("Item", args.item_code, "item_group")
 	if not args.brand:


### PR DESCRIPTION
# Fix Pricing Rule to Prioritize Bill To Customer

## Issue
When both `customer` and `bill_to` fields are set in Sales Order, pricing rules were being applied based on the main `customer` instead of the `bill_to` customer.

## Root Cause
The `update_args_for_pricing_rule()` function in `pricing_rule.py` was not properly prioritizing the `bill_to` field over the `customer` field for pricing rule selection.

### Debug notes, flow and fix

### 1. **Frontend Trigger**
- When customer and item are selected in Sales Order
- JavaScript `qty()` function calls `apply_pricing_rule(item)`
- Makes AJAX call to backend: `erpnext.accounts.doctype.pricing_rule.pricing_rule.apply_pricing_rule`

### 2. **Backend Processing**
```
apply_pricing_rule() 
  ↓
get_pricing_rule_for_item()
  ↓
update_args_for_pricing_rule() ← **FIXED HERE**
  ↓
get_pricing_rules() (in utils.py)
  ↓
_get_pricing_rules() (SQL query)
  ↓
get_other_conditions() (builds WHERE clause)
```

### 3. **The  Fix**
 In `update_args_for_pricing_rule()` function of `pricing_rule.py`, added condition to override the customer when bill_to is selected:
 
```python
if args.get("bill_to"):
    args.customer = args.bill_to
```

### 4. **Result**
Now when both `customer` and `bill_to` are set in a Sales Order:
- Pricing rules are fetched based on `bill_to` customer
- The `customer` field is temporarily overridden with `bill_to` value
- SQL queries use the correct customer for pricing rule lookup


## Testing
- Create Sales Order with different `customer` and `bill_to` values
- Add items and verify pricing rules are applied based on `bill_to` customer

**Case 1**: When only customer selected(Budget rental car) 
<img width="1745" height="702" alt="image" src="https://github.com/user-attachments/assets/1b68e624-0980-490e-a49e-cf18437ce26b" />

the default pricing rule applied BRAC Parts markup which is having 17.647 % markup
<img width="1749" height="641" alt="image" src="https://github.com/user-attachments/assets/daa89cba-a4c3-47cf-a509-1b988a184f82" />

the applied pricing rule for the item in sales order is BRAC Parts markup 
<img width="1696" height="787" alt="image" src="https://github.com/user-attachments/assets/a53ebf39-16c0-4751-ab8d-ff1b56c4aa2e" />

**Case 2**: Created new customer(Test customer-C0113) 
<img width="1755" height="761" alt="image" src="https://github.com/user-attachments/assets/8b877bfe-46d7-4a18-8cb4-86b4b1e98f6e" />

new pricing rule (Test customer pricing rule 20) which is having 20% as markup
<img width="1756" height="793" alt="image" src="https://github.com/user-attachments/assets/14365287-d911-499c-ae09-a2a12b71c0c4" />

the pricing rule applied for the item in the sales order is Test customer pricing rule 20
<img width="1747" height="827" alt="image" src="https://github.com/user-attachments/assets/c6b73761-0d3c-4e54-8f00-db5835018abf" />

**Case 3**: When customer Budget rental car as `customer`  and 'Test customer' is selected as `bill_to` customer is selected and  is selected
<img width="1768" height="815" alt="image" src="https://github.com/user-attachments/assets/ae6c420a-4bb1-44ab-983a-05ba8cef9170" />

The pricing rule applied for the sales order item is `Test customer pricing rule 20`
<img width="1739" height="836" alt="image" src="https://github.com/user-attachments/assets/4f27e811-3847-4eb6-851d-80b0cffa3c4c" />

Closes https://github.com/ParaLogicTech/erpnext/issues/468