### PR TITLE
fix(buying controller): not able to create debit note.

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -198,10 +198,13 @@ class BuyingController(TransactionController):
 			return
 
 		purchase_doc_field = 'purchase_receipt' if self.doctype == 'Purchase Receipt' else 'purchase_invoice'
-		not_cancelled_asset = [d.name for d in frappe.db.get_all("Asset", {
-			purchase_doc_field: self.return_against,
-			"docstatus": 1
-		})]
+		not_cancelled_asset = []
+		if self.return_against:
+			not_cancelled_asset = [
+				d.name
+				for d in frappe.db.get_all("Asset", {purchase_doc_field: self.return_against, "docstatus": 1})
+			]
+			
 		if self.is_return and len(not_cancelled_asset):
 			frappe.throw(_("{} has submitted assets linked to it. You need to cancel the assets to create purchase return.".format(self.return_against)),
 				title=_("Not Allowed"))


### PR DESCRIPTION
 validate_asset_return method shows error exception even if the return against voucher is not there.

<img width="1112" height="231" alt="Screenshot 2025-07-22 at 5 52 16 pm" src="https://github.com/user-attachments/assets/09fbef2b-42a3-403c-9a99-7b81e8adcc6f" />

against the [Issue#493](https://github.com/ParaLogicTech/erpnext/issues/493)

