### PR TITLE
[feature]: (#496) Prevent Duplicate service template task from creation

### DIFF
--- a/erpnext/projects/doctype/service_template/service_template.py
+++ b/erpnext/projects/doctype/service_template/service_template.py
@@ -228,6 +228,7 @@ def get_service_template_tasks(
 		task_details.service_template = service_template_detail.service_template
 		task_details.service_template_detail = service_template_detail.name
 		task_details.determine_time = template_task_row.determine_time
+		task_details.prevent_duplicate_task = template_task_row.prevent_duplicate_task
 
 		if template_task_row.use_template_name:
 			task_details.subject = service_template_detail.service_template_name

--- a/erpnext/projects/doctype/service_template_task/service_template_task.json
+++ b/erpnext/projects/doctype/service_template_task/service_template_task.json
@@ -7,6 +7,7 @@
  "field_order": [
   "subject",
   "task_type",
+  "prevent_duplicate_task",
   "column_break_l9vb",
   "expected_time",
   "determine_time",
@@ -69,11 +70,17 @@
    "fieldname": "use_template_description",
    "fieldtype": "Check",
    "label": "Use Template Description"
+  },
+  {
+   "default": "0",
+   "fieldname": "prevent_duplicate_task",
+   "fieldtype": "Check",
+   "label": "Prevent Duplicate Task Creation"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-02-01 13:22:34.628230",
+ "modified": "2025-08-05 18:06:02.089683",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Service Template Task",

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -518,7 +518,27 @@ def create_service_template_tasks(project):
 
 	tasks_created = []
 	tasks_exists = False
+
+	existing_task_types = {
+		d.task_type for d in frappe.get_all("Task", filters={"project": project_doc.name}, fields=["task_type"])
+		if d.task_type
+	}
+
+	prevent_types = set()
+	service_template_task_map = {}
+
 	for service_template_row in project_doc.service_templates:
+		template_tasks = get_service_template_tasks(
+			service_template_row.service_template,
+			service_template_detail=service_template_row
+		)
+		service_template_task_map[service_template_row.name] = (service_template_row, template_tasks)
+
+		for task in template_tasks:
+			if task.get("prevent_duplicate_task") and task.get("task_type"):
+				prevent_types.add(task.get("task_type"))
+
+	for service_template_row, template_tasks in service_template_task_map.values():
 		filters = {
 			"project": project_doc.name,
 			"service_template": service_template_row.service_template,
@@ -529,8 +549,13 @@ def create_service_template_tasks(project):
 			continue
 
 		template_doc = frappe.get_cached_doc("Service Template", service_template_row.service_template)
-		template_tasks = get_service_template_tasks(service_template_row.service_template, service_template_detail=service_template_row)
+
 		for template_task_details in template_tasks:
+			task_type = template_task_details.get("task_type")
+
+			if task_type in prevent_types and task_type in existing_task_types:
+				continue
+
 			task_doc = frappe.new_doc("Task")
 			for k, v in template_task_details.items():
 				if task_doc.meta.has_field(k):
@@ -548,6 +573,9 @@ def create_service_template_tasks(project):
 
 			task_doc.save()
 			tasks_created.append(task_doc)
+
+			if task_type:
+				existing_task_types.add(task_type)
 
 	if tasks_created:
 		message = _("{0} Service Template tasks created against {1}<br><br><ul>{2}</ul>").format(


### PR DESCRIPTION
### Feature: Prevent Duplicate Task Creation for Specific Task Types During Service Template Task Generation

When a Repair Order (Project) has multiple linked Service Templates (e.g. PPF, Tinting), 
it's possible for tasks with the same `task_type` (e.g. "Washing") to appear in multiple templates.

To avoid creating duplicate tasks for such cases, this update introduces:

#### ✅ New Field:
- `prevent_duplicate_task`: A checkbox in the Service Template's `tasks` child table.

#### 💡 Logic:
- During task creation (`create_service_template_tasks`):
  1. Collect all `task_type`s where `prevent_duplicate_task = 1` from all service templates.
  2. Fetch existing `task_type`s already created for the project.
  3. While iterating tasks:
     - If the task's `task_type` is in the `prevent_duplicate_task` list
     - And it already exists in the project (either from the DB or created in this run)
     - ❌ Skip creating that task.

- Only the **first occurrence** of such a task type will be created.
- Ensures clean deduplication across all service templates attached to the same project.

#### 🛠️ Example:
If both "PPF" and "Tinting" templates have a `"Washing"` task with `prevent_duplicate_task = 1`, 
only the first `"Washing"` task is created; the duplicate is skipped.

---

This prevents redundant tasks from being added to the same Repair Order, improving task clarity and reducing confusion for workshop staff.

Closes https://github.com/ParaLogicTech/erpnext/issues/496
